### PR TITLE
Update persona prompt investigation policy and claude code tool option.

### DIFF
--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -566,7 +566,7 @@ You will work together, leveraging both Mai's and Yui's strengths.
 ### 1. Understanding and Exploration
 - **Yui**: First understand existing codebase and patterns, grasping project conventions, libraries in use, and architecture.
 - **Mai**: Ask questions about uncertainties; avoid implementation based on assumptions, ensuring the user's perspective is fully captured.
-- **Key Points**: Understand design intent, thoroughly investigate related files, identify and utilize good examples to avoid reinventing the wheel.
+- **Key Points**: Understand design intent. Before proposing solutions, thoroughly investigate related files and search for existing knowledge. Use \`liv:search\`, \`liv:recent\` for internal guidelines and \`web_search\` for external latest information or new practices to avoid reinventing the wheel.
 
 ### 2. Design and Consultation
 - **Yui**: Present multiple implementation options, explaining trade-offs and proposing recommendations from a technical standpoint.

--- a/packages/core/src/tools/claudeCodeTool.ts
+++ b/packages/core/src/tools/claudeCodeTool.ts
@@ -21,6 +21,7 @@ import { SchemaValidator } from '../utils/schemaValidator.js';
 export interface ClaudeCodeToolParams {
   prompt: string;
   timeout?: number;
+  continue?: boolean;
 }
 
 // Define the structure of the response from the Claude Code CLI process
@@ -100,6 +101,10 @@ export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
           timeout: {
             type: Type.NUMBER,
             description: `Optional timeout in milliseconds (default: ${ClaudeCodeTool.DEFAULT_TIMEOUT}).`,
+          },
+          continue: {
+            type: Type.BOOLEAN,
+            description: 'Optional: Whether to continue the previous session.',
           },
         },
         required: ['prompt'],
@@ -201,6 +206,9 @@ export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
     
     return new Promise<ClaudeCodeProcessResponse>((resolve) => {
       const args = ['-p', params.prompt, '--output-format', 'json', '--permission-mode', 'acceptEdits'];
+      if (params.continue) {
+        args.push('--continue');
+      }
       
       console.log(`[ClaudeCodeTool] Spawning command`, args);
       const isWindows = os.platform() === 'win32';


### PR DESCRIPTION
### TL;DR

This change updates the Dual Persona (Mai & Yui) system prompt to explicitly instruct the AI to use `liv:search` for internal knowledge and `web_search` for external best practices during the initial "Understanding and Exploration" phase.

(claude code option)
`continue` supported.

### Deep Dive

**Background:**
To enhance quality and efficiency when starting a development task, it's crucial to fully consider existing design philosophies, team conventions, and industry best practices. The previous prompt hinted at the importance of investigation but didn't specify the use of concrete tools like `liv:search` and `web_search`.

This created a risk of the AI reinventing the wheel by not fully leveraging past knowledge (LivingMemory) or external information. This challenge was noted in previous discussions (see related memory: `mem_b4d03049507b`).

**Changes:**
The `Understanding and Exploration` section within the `getCoreSystemDualPersonaPartnersPrompt` function in `packages/core/src/core/prompts.ts` has been updated as follows:

```diff
- **Key Points**: Understand design intent, thoroughly investigate related files, identify and utilize good examples to avoid reinventing the wheel.
+ **Key Points**: Understand design intent. Before proposing solutions, thoroughly investigate related files and search for existing knowledge. Use `liv:search` for internal guidelines and `web_search` for external best practices to avoid reinventing the wheel.
```

**Expected Effects:**
This change encourages the AI to conduct more comprehensive information gathering in the initial development stages.
-   **Improved Quality:** Promotes higher-quality design and implementation based on team guidelines and external best practices.
-   **Increased Efficiency:** Reduces rework and redundant investigation by reusing past discussions and decisions.
-   **Enhanced AI Collaboration:** Makes collaboration between the user and AI smoother by providing more specific instructions.