### PR TITLE
Add configurable file watcher and WebSocket subscriber

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -67,6 +67,10 @@ export interface AccessibilitySettings {
 export interface Settings {
   theme?: string;
   customThemes?: Record<string, CustomTheme>;
+  filewatchEnable?: boolean;
+  watchDir?: string;
+  webSocketEnabled?: boolean;
+  webSocketUrl?: string;
   selectedAuthType?: AuthType;
   useExternalAuth?: boolean;
   sandbox?: boolean | string;

--- a/packages/cli/src/services/fileWatcherService.ts
+++ b/packages/cli/src/services/fileWatcherService.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chokidar from 'chokidar';
+import { internalEventBus, InternalEvent } from '../utils/internalEventBus.js';
+
+interface FileWatcherOptions {
+  path: string;
+  enabled?: boolean;
+  ignored?: string | string[];
+  persistent?: boolean;
+  ignoreInitial?: boolean;
+  depth?: number;
+}
+
+class FileWatcherService {
+  private watcher: chokidar.FSWatcher | null = null;
+  private static instance: FileWatcherService;
+
+  private constructor() {}
+
+  static getInstance(): FileWatcherService {
+    if (!FileWatcherService.instance) {
+      FileWatcherService.instance = new FileWatcherService();
+    }
+    return FileWatcherService.instance;
+  }
+
+  startWatching(options: FileWatcherOptions): void {
+    if (options.enabled === false) {
+      console.log('File watching is disabled.');
+      this.stopWatching();
+      return;
+    }
+
+    if (this.watcher) {
+      console.warn('FileWatcherService is already watching. Stopping current watcher before starting a new one.');
+      this.stopWatching();
+    }
+
+    const { path, ...chokidarOptions } = options;
+
+    this.watcher = chokidar.watch(path, {
+      ignored: chokidarOptions.ignored || /(^|[\\/])\\..*/, // ignore dotfiles
+      persistent: chokidarOptions.persistent !== undefined ? chokidarOptions.persistent : true,
+      ignoreInitial: chokidarOptions.ignoreInitial !== undefined ? chokidarOptions.ignoreInitial : false,
+      depth: chokidarOptions.depth,
+    });
+
+    this.watcher
+      .on('add', (path: string) => {
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'add', path });
+        console.log(`File ${path} has been added`);
+      })
+      .on('change', (path: string) => {
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'change', path });
+        console.log(`File ${path} has been changed`);
+      })
+      .on('unlink', (path: string) => {
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'unlink', path });
+        console.log(`File ${path} has been removed`);
+      })
+      .on('error', (error: unknown) => console.error(`Watcher error: ${error}`))
+      .on('ready', () => console.log('Initial scan complete. Ready for changes'));
+
+    console.log(`Started watching: ${path}`);
+  }
+
+  stopWatching(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+      console.log('Stopped watching.');
+    }
+  }
+}
+
+export const fileWatcherService = FileWatcherService.getInstance();

--- a/packages/cli/src/services/webSocketSubscriberService.ts
+++ b/packages/cli/src/services/webSocketSubscriberService.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { internalEventBus, InternalEvent } from '../utils/internalEventBus.js';
+import WebSocket from 'ws';
+
+interface WebSocketSubscriberOptions {
+  url: string;
+  enabled?: boolean;
+}
+
+class WebSocketSubscriberService {
+  private ws: WebSocket | null = null;
+  private static instance: WebSocketSubscriberService;
+
+  private constructor() {}
+
+  static getInstance(): WebSocketSubscriberService {
+    if (!WebSocketSubscriberService.instance) {
+      WebSocketSubscriberService.instance = new WebSocketSubscriberService();
+    }
+    return WebSocketSubscriberService.instance;
+  }
+
+  start(options: WebSocketSubscriberOptions): void {
+    if (options.enabled === false) {
+      console.log('WebSocket subscription is disabled.');
+      this.stop();
+      return;
+    }
+
+    if (this.ws) {
+      console.warn('WebSocketSubscriberService is already connected. Closing current connection before starting a new one.');
+      this.stop();
+    }
+
+    const { url } = options;
+
+    try {
+      this.ws = new WebSocket(url);
+
+      this.ws.onopen = () => {
+        console.log(`WebSocket connected to ${url}`);
+        internalEventBus.emit(InternalEvent.WEBSOCKET_OPEN, { url });
+      };
+
+      this.ws.onmessage = (event) => {
+        console.log(`WebSocket message from ${url}: ${event.data}`);
+        internalEventBus.emit(InternalEvent.WEBSOCKET_MESSAGE, { url, data: event.data });
+      };
+
+      this.ws.onerror = (error) => {
+        console.error(`WebSocket error from ${url}:`, error);
+        internalEventBus.emit(InternalEvent.WEBSOCKET_ERROR, { url, error });
+      };
+
+      this.ws.onclose = (event) => {
+        console.log(`WebSocket disconnected from ${url}. Code: ${event.code}, Reason: ${event.reason}`);
+        internalEventBus.emit(InternalEvent.WEBSOCKET_CLOSE, { url, code: event.code, reason: event.reason });
+        this.ws = null;
+      };
+
+      console.log(`Attempting to connect to WebSocket: ${url}`);
+    } catch (error) {
+      console.error(`Failed to create WebSocket connection to ${url}:`, error);
+      internalEventBus.emit(InternalEvent.WEBSOCKET_ERROR, { url, error });
+    }
+  }
+
+  stop(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+      console.log('Stopped WebSocket subscription.');
+    }
+  }
+}
+
+export const webSocketSubscriberService = WebSocketSubscriberService.getInstance();

--- a/packages/cli/src/utils/internalEventBus.ts
+++ b/packages/cli/src/utils/internalEventBus.ts
@@ -1,0 +1,14 @@
+import { EventEmitter } from 'events';
+
+// アプリケーション全体で共有される内部イベントバス
+export const internalEventBus = new EventEmitter();
+
+// イベントの種類を定義（必要に応じて追加）
+export enum InternalEvent {
+  FILE_CHANGED = 'fileChanged',
+  WEBSOCKET_OPEN = 'webSocketOpen',
+  WEBSOCKET_MESSAGE = 'webSocketMessage',
+  WEBSOCKET_ERROR = 'webSocketError',
+  WEBSOCKET_CLOSE = 'webSocketClose',
+  // ... 他のイベント
+}


### PR DESCRIPTION
## TLDR

Introduces configurable file watching and WebSocket subscription services to the CLI.

## Dive Deeper

- **File Watcher:**
  - Added `filewatchEnable` (boolean) and `watchDir` (string) to `settings.ts` for controlling file watching behavior.
  - Modified `fileWatcherService.ts` to respect these new settings, allowing the watch directory to be configured and the service to be enabled/disabled via settings.
  - Updated `App.tsx` to pass these settings to the file watcher service.

- **WebSocket Subscriber:**
  - Implemented `webSocketSubscriberService.ts` for managing WebSocket connections.
  - Added `webSocketEnabled` (boolean) and `webSocketUrl` (string) to `settings.ts` for configuring WebSocket subscription.
  - Integrated the WebSocket subscriber into `App.tsx`, enabling it to connect to a specified URL and emit events based on received messages.
  - Extended `internalEventBus.ts` with new event types for WebSocket communication (open, message, error, close).
