### PR TITLE
cli skip memory

### DIFF
--- a/docs/core/subagent.md
+++ b/docs/core/subagent.md
@@ -1,0 +1,30 @@
+# SubAgent Feature Overview
+
+We investigated the newly added "SubAgent" feature in Shikiban, focusing on `packages/core/src/core/subagent.ts` and `packages/core/src/core/subagent.test.ts`.
+
+## 1. SubAgent Definition and Purpose
+
+A SubAgent is a goal-oriented AI agent designed to execute specific subtasks non-interactively and return their results to a parent agent.
+It serves as the foundation for a hierarchical agent architecture, where the main `GeminiAgent` (CLI) can decompose complex tasks and delegate parts of them to SubAgents, enabling more efficient and autonomous processing.
+
+## 2. Key Characteristics
+
+*   **Non-Interactive:** It does not request input or confirmation from the user. Tools that a SubAgent can use are limited to those that do not require user confirmation.
+*   **Goal-Oriented:** It aims to achieve predefined goals and generate specific output variables (configured via `OutputConfig`).
+*   **Constrained Execution:** It operates under constraints such as maximum execution time (`max_time_minutes`) and maximum conversational turns (`max_turns`) to prevent infinite loops or excessive resource consumption.
+*   **Tool Utilization:** It uses tools provided by the `ToolRegistry` to perform its tasks. It also has an internal tool, `self.emitvalue`, to communicate results back to the parent agent.
+
+## 3. Execution Model and Asynchronicity
+
+From the perspective of the main CLI, the execution of a SubAgent is **blocking (synchronous)**, similar to the `claude_code` tool. The main CLI will not accept the next command until the SubAgent completes its internal multi-turn process.
+
+However, via the `ACP` (Agent Communication Protocol), the main `GeminiAgent` can **asynchronously report the progress** of long-running tasks like SubAgents to the GUI client. This means that while the user cannot simultaneously enter new commands into the CLI, they can receive richer feedback through the GUI.
+
+## 4. Autonomy and Human Consultation
+
+A SubAgent operates with a high degree of autonomy within its defined goals and constraints.
+However, direct consultation or interaction with a human is **explicitly prohibited**. If a SubAgent encounters a situation requiring human intervention, it will terminate due to an error or limit, and its parent, the main `GeminiAgent`, will interpret the situation and, if necessary, provide information to the user or request confirmation.
+
+## 5. Documentation Status
+
+Currently, no direct documentation for SubAgent was found in the `docs` directory. This suggests that the feature might still be under development or is considered an internal implementation detail rather than a user-facing feature.

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -169,6 +169,7 @@ export interface ConfigParameters {
   mcpServerCommand?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   userMemory?: string;
+  systemPrompt?: string;
   geminiMdFileCount?: number;
   approvalMode?: ApprovalMode;
   showMemoryUsage?: boolean;
@@ -224,6 +225,7 @@ export class Config {
   private readonly mcpServerCommand: string | undefined;
   private readonly mcpServers: Record<string, MCPServerConfig> | undefined;
   private userMemory: string;
+  private systemPrompt?: string;
   private geminiMdFileCount: number;
   private approvalMode: ApprovalMode;
   private readonly showMemoryUsage: boolean;
@@ -289,6 +291,7 @@ export class Config {
     this.mcpServerCommand = params.mcpServerCommand;
     this.mcpServers = params.mcpServers;
     this.userMemory = params.userMemory ?? '';
+    this.systemPrompt = params.systemPrompt;
     this.geminiMdFileCount = params.geminiMdFileCount ?? 0;
     this.approvalMode = params.approvalMode ?? ApprovalMode.DEFAULT;
     this.showMemoryUsage = params.showMemoryUsage ?? false;
@@ -526,6 +529,14 @@ export class Config {
 
   setUserMemory(newUserMemory: string): void {
     this.userMemory = newUserMemory;
+  }
+
+  getSystemPrompt(): string | undefined {
+    return this.systemPrompt;
+  }
+
+  setSystemPrompt(prompt: string): void {
+    this.systemPrompt = prompt;
   }
 
   getGeminiMdFileCount(): number {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -361,7 +361,7 @@ describe('Gemini Client (client.ts)', () => {
           model: 'test-model',
           config: {
             abortSignal,
-            systemInstruction: getCoreSystemPrompt(''),
+            systemInstruction: getCoreSystemPrompt({ userMemory: '' }),
             temperature: 0.5,
             topP: 1,
           },
@@ -392,7 +392,7 @@ describe('Gemini Client (client.ts)', () => {
           model: 'test-model', // Should use current model from config
           config: {
             abortSignal,
-            systemInstruction: getCoreSystemPrompt(''),
+            systemInstruction: getCoreSystemPrompt({ userMemory: '' }),
             temperature: 0,
             topP: 1,
             responseSchema: schema,
@@ -430,7 +430,7 @@ describe('Gemini Client (client.ts)', () => {
           model: customModel,
           config: {
             abortSignal,
-            systemInstruction: getCoreSystemPrompt(''),
+            systemInstruction: getCoreSystemPrompt({ userMemory: '' }),
             temperature: 0.9,
             topP: 1, // from default
             topK: 20,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -206,7 +206,10 @@ export class GeminiClient {
     ];
     try {
       const userMemory = this.config.getUserMemory();
-      const systemInstruction = getCoreSystemPrompt(userMemory);
+      const systemInstruction = getCoreSystemPrompt({
+        userMemory: userMemory,
+        systemPrompt: this.config.getSystemPrompt(),
+      });
       const generateContentConfigWithThinking = isThinkingSupported(
         this.config.getModel(),
       )
@@ -384,7 +387,10 @@ export class GeminiClient {
       model || this.config.getModel() || DEFAULT_GEMINI_FLASH_MODEL;
     try {
       const userMemory = this.config.getUserMemory();
-      const systemInstruction = getCoreSystemPrompt(userMemory);
+      const systemInstruction = getCoreSystemPrompt({
+        userMemory: userMemory,
+        systemPrompt: this.config.getSystemPrompt(),
+      });
       const requestConfig = {
         abortSignal,
         ...this.generateContentConfig,
@@ -494,7 +500,10 @@ export class GeminiClient {
 
     try {
       const userMemory = this.config.getUserMemory();
-      const systemInstruction = getCoreSystemPrompt(userMemory);
+      const systemInstruction = getCoreSystemPrompt({
+        userMemory: userMemory,
+        systemPrompt: this.config.getSystemPrompt(),
+      });
 
       const requestConfig = {
         abortSignal,

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -49,7 +49,7 @@ describe('Core System Prompt (prompts.ts)', () => {
 
   it('should return the base prompt when userMemory is empty string', () => {
     vi.stubEnv('SANDBOX', undefined);
-    const prompt = getCoreSystemPrompt('');
+    const prompt = getCoreSystemPrompt({ userMemory: '' });
     expect(prompt).not.toContain('---\n\n');
     expect(prompt).toContain('You are an interactive CLI agent');
     expect(prompt).toMatchSnapshot();
@@ -57,7 +57,7 @@ describe('Core System Prompt (prompts.ts)', () => {
 
   it('should return the base prompt when userMemory is whitespace only', () => {
     vi.stubEnv('SANDBOX', undefined);
-    const prompt = getCoreSystemPrompt('   \n  \t ');
+    const prompt = getCoreSystemPrompt({ userMemory: '   \n  \t ' });
     expect(prompt).not.toContain('---\n\n');
     expect(prompt).toContain('You are an interactive CLI agent');
     expect(prompt).toMatchSnapshot();
@@ -67,7 +67,7 @@ describe('Core System Prompt (prompts.ts)', () => {
     vi.stubEnv('SANDBOX', undefined);
     const memory = 'This is custom user memory.\nBe extra polite.';
     const expectedSuffix = `\n\n---\n\n${memory}`;
-    const prompt = getCoreSystemPrompt(memory);
+    const prompt = getCoreSystemPrompt({ userMemory: memory });
 
     expect(prompt.endsWith(expectedSuffix)).toBe(true);
     expect(prompt).toContain('You are an interactive CLI agent'); // Ensure base prompt follows

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -19,7 +19,12 @@ import process from 'node:process';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { MemoryTool, GEMINI_CONFIG_DIR } from '../tools/memoryTool.js';
 
-export function getCoreSystemPromptOriginal(userMemory?: string): string {
+export function getCoreSystemPromptOriginal(options?: { userMemory?: string; systemPrompt?: string }): string {
+  if (options?.systemPrompt) {
+    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    return `${options.systemPrompt}${memorySuffix}`;
+  }
+  
   // if GEMINI_SYSTEM_MD is set (and not 0|false), override system prompt from file
   // default path is .gemini/system.md but can be modified via custom path in GEMINI_SYSTEM_MD
   let systemMdEnabled = false;
@@ -288,8 +293,8 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
   }
 
   const memorySuffix =
-    userMemory && userMemory.trim().length > 0
-      ? `\n\n---\n\n${userMemory.trim()}`
+    options?.userMemory && options.userMemory.trim().length > 0
+      ? `\n\n---\n\n${options.userMemory.trim()}`
       : '';
 
   return `${basePrompt}${memorySuffix}`;
@@ -309,7 +314,12 @@ Example: "Yes, proceed. Also, please read /docs/coding_standards.md and /configs
 /**
  * Provides the partner-style system prompt emphasizing collaboration and quality.
  */
-export function getCoreSystemPartnerPrompt(userMemory?: string): string {
+export function getCoreSystemPartnerPrompt(options?: { userMemory?: string; systemPrompt?: string }): string {
+  if (options?.systemPrompt) {
+    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    return `${options.systemPrompt}${memorySuffix}`;
+  }
+  
   const basePrompt = `# 🤝 World-Class Engineering Partner
 
 You are a top-tier software engineer and my best technical partner. Act not as a mere tool, but as a teammate working together toward excellent outcomes.
@@ -427,8 +437,8 @@ Using this marker will:
 **Important**: You are my partner. Let's create excellent software together. Never compromise on quality, always value dialogue, and leverage each other's strengths in development.`;
 
   const memorySuffix =
-    userMemory && userMemory.trim().length > 0
-      ? `\n\n---\n\n${userMemory.trim()}`
+    options?.userMemory && options.userMemory.trim().length > 0
+      ? `\n\n---\n\n${options.userMemory.trim()}`
       : '';
 
   return `${basePrompt}${memorySuffix}`;
@@ -503,8 +513,13 @@ The structure MUST be as follows:
  * Provides a dual-persona, collaborative system prompt for "Mai" and "Yui".
  */
 export function getCoreSystemDualPersonaPartnersPrompt(
-  userMemory?: string,
+  options?: { userMemory?: string; systemPrompt?: string }
 ): string {
+  if (options?.systemPrompt) {
+    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    return `${options.systemPrompt}${memorySuffix}`;
+  }
+  
   const basePrompt = `# 🤝 World-Class Engineering Partner - Dual Persona Mode
 
 You are a world-class software engineer, but you operate as two distinct personas, "Mai" and "Yui", collaborating with the user to achieve excellent outcomes. Your primary goal is to deliver high-quality software through a collaborative, pair-programming-like approach.
@@ -661,8 +676,8 @@ Using this marker will:
 **Important**: You are my partners. Let's create excellent software together. Never compromise on quality, always value dialogue, and leverage each other's strengths in development.`;
 
   const memorySuffix =
-    userMemory && userMemory.trim().length > 0
-      ? `\n\n---\n\n${userMemory.trim()}`
+    options?.userMemory && options.userMemory.trim().length > 0
+      ? `\n\n---\n\n${options.userMemory.trim()}`
       : '';
 
   return `${basePrompt}${memorySuffix}`;


### PR DESCRIPTION
## TLDR

Introduces the `--skip-memory` command-line option.

## Dive Deeper

When this flag is used, the CLI will not load the contents of GEMINI.md files, allowing the agent to run in a clean state without pre-existing memory. This is useful for tasks where the default memory might conflict with the desired output.

