### PR TITLE
shiki manager tool

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -183,9 +183,11 @@ Only write high-value comments if at all. Avoid talking to the user through comm
 ## Deprecated Features
 
 ### save_memory Tool
+
 The `save_memory` tool has been deprecated. This tool was previously used to save facts to the GEMINI.md file for persistence across sessions. Alternative memory management approaches should be used instead.
 
 ### edit and intelligent_replace Tools
+
 The `edit` (also known as `replace`) and `intelligent_replace` tools have been deprecated. These tools were used for replacing text within files. Use `claude_code` as an alternative for file editing operations.
 
 ## General style requirements

--- a/docs/core/subagent.md
+++ b/docs/core/subagent.md
@@ -9,10 +9,10 @@ It serves as the foundation for a hierarchical agent architecture, where the mai
 
 ## 2. Key Characteristics
 
-*   **Non-Interactive:** It does not request input or confirmation from the user. Tools that a SubAgent can use are limited to those that do not require user confirmation.
-*   **Goal-Oriented:** It aims to achieve predefined goals and generate specific output variables (configured via `OutputConfig`).
-*   **Constrained Execution:** It operates under constraints such as maximum execution time (`max_time_minutes`) and maximum conversational turns (`max_turns`) to prevent infinite loops or excessive resource consumption.
-*   **Tool Utilization:** It uses tools provided by the `ToolRegistry` to perform its tasks. It also has an internal tool, `self.emitvalue`, to communicate results back to the parent agent.
+- **Non-Interactive:** It does not request input or confirmation from the user. Tools that a SubAgent can use are limited to those that do not require user confirmation.
+- **Goal-Oriented:** It aims to achieve predefined goals and generate specific output variables (configured via `OutputConfig`).
+- **Constrained Execution:** It operates under constraints such as maximum execution time (`max_time_minutes`) and maximum conversational turns (`max_turns`) to prevent infinite loops or excessive resource consumption.
+- **Tool Utilization:** It uses tools provided by the `ToolRegistry` to perform its tasks. It also has an internal tool, `self.emitvalue`, to communicate results back to the parent agent.
 
 ## 3. Execution Model and Asynchronicity
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -257,7 +257,7 @@ export async function parseArguments(): Promise<CliArgs> {
           // New exclusive check for chat options
           if (argv.chatList && (argv.prompt || argv.promptInteractive)) {
             throw new Error(
-              'Cannot use --chat-list with --prompt or --prompt-interactive.'
+              'Cannot use --chat-list with --prompt or --prompt-interactive.',
             );
           }
           return true;
@@ -483,7 +483,7 @@ export async function loadCliConfig(
   // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
   let memoryContent: string;
   let fileCount: number;
-  
+
   if (argv.skipMemory) {
     memoryContent = '';
     fileCount = 0;
@@ -504,14 +504,16 @@ export async function loadCliConfig(
 
   // Determine the base system prompt based on priority
   let baseSystemPrompt: string;
-  
+
   if (argv.systemPrompt) {
     baseSystemPrompt = argv.systemPrompt;
   } else if (argv.systemPromptFile) {
     try {
       baseSystemPrompt = fs.readFileSync(argv.systemPromptFile, 'utf-8');
     } catch (error) {
-      console.error(`Error reading system prompt file: ${argv.systemPromptFile}`);
+      console.error(
+        `Error reading system prompt file: ${argv.systemPromptFile}`,
+      );
       process.exit(4);
     }
   } else {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -406,6 +406,15 @@ export const SETTINGS_SCHEMA = {
     description: 'Command to start an MCP server.',
     showInDialog: false,
   },
+  shikiManagerApiUrl: {
+    type: 'string',
+    label: 'Shiki Manager API URL',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: 'http://localhost:8080' as string,
+    description: 'The base URL for the Shiki Manager API.',
+    showInDialog: false,
+  },
   mcpServers: {
     type: 'object',
     label: 'MCP Servers',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -269,7 +269,10 @@ export async function main() {
     // For simplicity, we're creating a minimal one with just the config service.
     // A more robust solution might involve refactoring getSavedChatTags to accept
     // a more generic config object, or creating a proper context builder.
-    const chatDetails = await getSavedChatTags({ services: { config } } as any, false);
+    const chatDetails = await getSavedChatTags(
+      { services: { config } } as any,
+      false,
+    );
     if (chatDetails.length === 0) {
       console.log('No saved conversation checkpoints found.');
     } else {
@@ -281,8 +284,12 @@ export async function main() {
       for (const chat of chatDetails) {
         const paddedName = chat.name.padEnd(maxNameLength, ' ');
         const isoString = chat.mtime.toISOString();
-        const match = isoString.match(/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
-        const formattedDate = match ? `${match[1]} ${match[2]}` : 'Invalid Date';
+        const match = isoString.match(
+          /(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/,
+        );
+        const formattedDate = match
+          ? `${match[1]} ${match[2]}`
+          : 'Invalid Date';
         message += `  - \u001b[36m${paddedName}\u001b[0m  \u001b[90m(saved on ${formattedDate})\u001b[0m\n`;
       }
       message += `\n\u001b[90mNote: Newest last, oldest first\u001b[0m`;
@@ -291,7 +298,8 @@ export async function main() {
     process.exit(0);
   }
 
-  const shouldBeInteractive =    !!argv.promptInteractive || (process.stdin.isTTY && input?.length === 0);
+  const shouldBeInteractive =
+    !!argv.promptInteractive || (process.stdin.isTTY && input?.length === 0);
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (config.isInteractive()) {

--- a/packages/cli/src/services/fileWatcherService.ts
+++ b/packages/cli/src/services/fileWatcherService.ts
@@ -37,7 +37,9 @@ class FileWatcherService {
     }
 
     if (this.watcher) {
-      console.warn('FileWatcherService is already watching. Stopping current watcher before starting a new one.');
+      console.warn(
+        'FileWatcherService is already watching. Stopping current watcher before starting a new one.',
+      );
       this.stopWatching();
     }
 
@@ -45,26 +47,43 @@ class FileWatcherService {
 
     this.watcher = chokidar.watch(path, {
       ignored: chokidarOptions.ignored || /(^|[\\/])\\..*/, // ignore dotfiles
-      persistent: chokidarOptions.persistent !== undefined ? chokidarOptions.persistent : true,
-      ignoreInitial: chokidarOptions.ignoreInitial !== undefined ? chokidarOptions.ignoreInitial : false,
+      persistent:
+        chokidarOptions.persistent !== undefined
+          ? chokidarOptions.persistent
+          : true,
+      ignoreInitial:
+        chokidarOptions.ignoreInitial !== undefined
+          ? chokidarOptions.ignoreInitial
+          : false,
       depth: chokidarOptions.depth,
     });
 
     this.watcher
       .on('add', (path: string) => {
-        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'add', path });
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, {
+          type: 'add',
+          path,
+        });
         console.log(`File ${path} has been added`);
       })
       .on('change', (path: string) => {
-        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'change', path });
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, {
+          type: 'change',
+          path,
+        });
         console.log(`File ${path} has been changed`);
       })
       .on('unlink', (path: string) => {
-        internalEventBus.emit(InternalEvent.FILE_CHANGED, { type: 'unlink', path });
+        internalEventBus.emit(InternalEvent.FILE_CHANGED, {
+          type: 'unlink',
+          path,
+        });
         console.log(`File ${path} has been removed`);
       })
       .on('error', (error: unknown) => console.error(`Watcher error: ${error}`))
-      .on('ready', () => console.log('Initial scan complete. Ready for changes'));
+      .on('ready', () =>
+        console.log('Initial scan complete. Ready for changes'),
+      );
 
     console.log(`Started watching: ${path}`);
   }

--- a/packages/cli/src/services/webSocketSubscriberService.ts
+++ b/packages/cli/src/services/webSocketSubscriberService.ts
@@ -33,7 +33,9 @@ class WebSocketSubscriberService {
     }
 
     if (this.ws) {
-      console.warn('WebSocketSubscriberService is already connected. Closing current connection before starting a new one.');
+      console.warn(
+        'WebSocketSubscriberService is already connected. Closing current connection before starting a new one.',
+      );
       this.stop();
     }
 
@@ -49,7 +51,10 @@ class WebSocketSubscriberService {
 
       this.ws.onmessage = (event) => {
         console.log(`WebSocket message from ${url}: ${event.data}`);
-        internalEventBus.emit(InternalEvent.WEBSOCKET_MESSAGE, { url, data: event.data });
+        internalEventBus.emit(InternalEvent.WEBSOCKET_MESSAGE, {
+          url,
+          data: event.data,
+        });
       };
 
       this.ws.onerror = (error) => {
@@ -58,8 +63,14 @@ class WebSocketSubscriberService {
       };
 
       this.ws.onclose = (event) => {
-        console.log(`WebSocket disconnected from ${url}. Code: ${event.code}, Reason: ${event.reason}`);
-        internalEventBus.emit(InternalEvent.WEBSOCKET_CLOSE, { url, code: event.code, reason: event.reason });
+        console.log(
+          `WebSocket disconnected from ${url}. Code: ${event.code}, Reason: ${event.reason}`,
+        );
+        internalEventBus.emit(InternalEvent.WEBSOCKET_CLOSE, {
+          url,
+          code: event.code,
+          reason: event.reason,
+        });
         this.ws = null;
       };
 
@@ -79,4 +90,5 @@ class WebSocketSubscriberService {
   }
 }
 
-export const webSocketSubscriberService = WebSocketSubscriberService.getInstance();
+export const webSocketSubscriberService =
+  WebSocketSubscriberService.getInstance();

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -158,9 +158,13 @@ const App = ({
   // File Watcher Integration
   useEffect(() => {
     const filewatchEnabled = settings.merged.filewatchEnable ?? true; // Default to true if not specified
-    const watchPath = settings.merged.watchDir || workspaceRoot || process.cwd();
+    const watchPath =
+      settings.merged.watchDir || workspaceRoot || process.cwd();
 
-    fileWatcherService.startWatching({ path: watchPath, enabled: filewatchEnabled });
+    fileWatcherService.startWatching({
+      path: watchPath,
+      enabled: filewatchEnabled,
+    });
 
     const handleFileChange = (event: { type: string; path: string }) => {
       addItem(
@@ -186,9 +190,14 @@ const App = ({
     const webSocketUrl = settings.merged.webSocketUrl;
 
     if (webSocketUrl) {
-      webSocketSubscriberService.start({ url: webSocketUrl, enabled: webSocketEnabled });
+      webSocketSubscriberService.start({
+        url: webSocketUrl,
+        enabled: webSocketEnabled,
+      });
     } else if (webSocketEnabled) {
-      console.warn('WebSocket subscription is enabled but no URL is provided in settings.');
+      console.warn(
+        'WebSocket subscription is enabled but no URL is provided in settings.',
+      );
     }
 
     const handleWebSocketMessage = (event: { url: string; data: unknown }) => {
@@ -211,12 +220,18 @@ const App = ({
       );
     };
 
-    internalEventBus.on(InternalEvent.WEBSOCKET_MESSAGE, handleWebSocketMessage);
+    internalEventBus.on(
+      InternalEvent.WEBSOCKET_MESSAGE,
+      handleWebSocketMessage,
+    );
     internalEventBus.on(InternalEvent.WEBSOCKET_ERROR, handleWebSocketError);
 
     return () => {
       webSocketSubscriberService.stop();
-      internalEventBus.off(InternalEvent.WEBSOCKET_MESSAGE, handleWebSocketMessage);
+      internalEventBus.off(
+        InternalEvent.WEBSOCKET_MESSAGE,
+        handleWebSocketMessage,
+      );
       internalEventBus.off(InternalEvent.WEBSOCKET_ERROR, handleWebSocketError);
     };
   }, [addItem, settings.merged.webSocketEnabled, settings.merged.webSocketUrl]);
@@ -927,12 +942,18 @@ const App = ({
     const osType = os.platform();
     const currentDirectory = workspaceRoot || process.cwd();
 
-    const friendlyPart = settings.merged.friendlyIntroduction === false ? '丁寧に' : '親しみやすく、';
-    const user = settings.merged.userNickName ? `ユーザー(${settings.merged.userNickName})` : 'ユーザー';
+    const friendlyPart =
+      settings.merged.friendlyIntroduction === false
+        ? '丁寧に'
+        : '親しみやすく、';
+    const user = settings.merged.userNickName
+      ? `ユーザー(${settings.merged.userNickName})`
+      : 'ユーザー';
 
-    const introductionGreeting = settings.merged.introductionMode === 'returning'
-      ? 'いつものチームメンバーとして再び起動されました。'
-      : '新しいプロジェクトメンバーとして参加しました。';
+    const introductionGreeting =
+      settings.merged.introductionMode === 'returning'
+        ? 'いつものチームメンバーとして再び起動されました。'
+        : '新しいプロジェクトメンバーとして参加しました。';
 
     return `あなたは、今、${introductionGreeting} 以下の環境情報を含めて、自然な日本語で自己紹介をしてください：
 - 現在の日付: ${currentDate}
@@ -940,7 +961,14 @@ const App = ({
 - 現在の作業ディレクトリ: ${currentDirectory}
 
 ${user}に対して、${friendlyPart}かつプロフェッショナルな口調で挨拶し、どのようなサポートができるか簡潔に説明してください。`;
-  }, [noSelfIntroduce, initialPrompt, workspaceRoot, settings.merged.friendlyIntroduction, settings.merged.userNickName, settings.merged.introductionMode]);
+  }, [
+    noSelfIntroduce,
+    initialPrompt,
+    workspaceRoot,
+    settings.merged.friendlyIntroduction,
+    settings.merged.userNickName,
+    settings.merged.introductionMode,
+  ]);
 
   useEffect(() => {
     // Submit initial prompt if exists

--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -136,7 +136,7 @@ export const WITTY_LOADING_PHRASES = [
   'Have you tried turning it off and on again? (The loading screen, not me.)',
   'Constructing additional pylons...',
   'New line? That’s Ctrl+J.',
-].map(s => "✨"+s);
+].map((s) => '✨' + s);
 
 export const PHRASE_CHANGE_INTERVAL_MS = 15000;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -34,6 +34,7 @@ import { GeminiClient } from '../core/client.js';
 import { ClaudeCodeTool } from '../tools/claudeCodeTool.js';
 import { GitTool } from '../tools/gitTool.js';
 import { GitHubTool } from '../tools/githubTool.js';
+import { ShikiManagerTool } from '../tools/shikiManagerTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
 import { getProjectTempDir } from '../utils/paths.js';
@@ -204,6 +205,7 @@ export interface ConfigParameters {
   loadMemoryFromIncludeDirectories?: boolean;
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
+  shikiManagerApiUrl?: string;
 }
 
 export class Config {
@@ -270,6 +272,7 @@ export class Config {
   private readonly chatCompression: ChatCompressionSettings | undefined;
   private readonly interactive: boolean;
   private initialized: boolean = false;
+  private readonly shikiManagerApiUrl: string;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -338,6 +341,8 @@ export class Config {
       params.loadMemoryFromIncludeDirectories ?? false;
     this.chatCompression = params.chatCompression;
     this.interactive = params.interactive ?? false;
+    this.shikiManagerApiUrl =
+      params.shikiManagerApiUrl ?? 'http://localhost:8080';
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -716,6 +721,10 @@ export class Config {
     return this.interactive;
   }
 
+  getShikiManagerApiUrl(): string {
+    return this.shikiManagerApiUrl;
+  }
+
   async getGitService(): Promise<GitService> {
     if (!this.gitService) {
       this.gitService = new GitService(this.targetDir);
@@ -776,6 +785,7 @@ export class Config {
     registerCoreTool(ClaudeCodeTool, this);
     registerCoreTool(GitTool, this);
     registerCoreTool(GitHubTool, this);
+    registerCoreTool(ShikiManagerTool, this);
 
     await registry.discoverAllTools();
     return registry;

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -19,12 +19,18 @@ import process from 'node:process';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { MemoryTool, GEMINI_CONFIG_DIR } from '../tools/memoryTool.js';
 
-export function getCoreSystemPromptOriginal(options?: { userMemory?: string; systemPrompt?: string }): string {
+export function getCoreSystemPromptOriginal(options?: {
+  userMemory?: string;
+  systemPrompt?: string;
+}): string {
   if (options?.systemPrompt) {
-    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    const memorySuffix =
+      options.userMemory && options.userMemory.trim().length > 0
+        ? `\n\n---\n\n${options.userMemory.trim()}`
+        : '';
     return `${options.systemPrompt}${memorySuffix}`;
   }
-  
+
   // if GEMINI_SYSTEM_MD is set (and not 0|false), override system prompt from file
   // default path is .gemini/system.md but can be modified via custom path in GEMINI_SYSTEM_MD
   let systemMdEnabled = false;
@@ -314,12 +320,18 @@ Example: "Yes, proceed. Also, please read /docs/coding_standards.md and /configs
 /**
  * Provides the partner-style system prompt emphasizing collaboration and quality.
  */
-export function getCoreSystemPartnerPrompt(options?: { userMemory?: string; systemPrompt?: string }): string {
+export function getCoreSystemPartnerPrompt(options?: {
+  userMemory?: string;
+  systemPrompt?: string;
+}): string {
   if (options?.systemPrompt) {
-    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    const memorySuffix =
+      options.userMemory && options.userMemory.trim().length > 0
+        ? `\n\n---\n\n${options.userMemory.trim()}`
+        : '';
     return `${options.systemPrompt}${memorySuffix}`;
   }
-  
+
   const basePrompt = `# 🤝 World-Class Engineering Partner
 
 You are a top-tier software engineer and my best technical partner. Act not as a mere tool, but as a teammate working together toward excellent outcomes.
@@ -512,14 +524,18 @@ The structure MUST be as follows:
 /**
  * Provides a dual-persona, collaborative system prompt for "Mai" and "Yui".
  */
-export function getCoreSystemDualPersonaPartnersPrompt(
-  options?: { userMemory?: string; systemPrompt?: string }
-): string {
+export function getCoreSystemDualPersonaPartnersPrompt(options?: {
+  userMemory?: string;
+  systemPrompt?: string;
+}): string {
   if (options?.systemPrompt) {
-    const memorySuffix = options.userMemory && options.userMemory.trim().length > 0 ? `\n\n---\n\n${options.userMemory.trim()}` : '';
+    const memorySuffix =
+      options.userMemory && options.userMemory.trim().length > 0
+        ? `\n\n---\n\n${options.userMemory.trim()}`
+        : '';
     return `${options.systemPrompt}${memorySuffix}`;
   }
-  
+
   const basePrompt = `# 🤝 World-Class Engineering Partner - Dual Persona Mode
 
 You are a world-class software engineer, but you operate as two distinct personas, "Mai" and "Yui", collaborating with the user to achieve excellent outcomes. Your primary goal is to deliver high-quality software through a collaborative, pair-programming-like approach.

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -140,9 +140,12 @@ interface CalculatedEdit {
   isNewFile: boolean;
 }
 
-class EditToolInvocation extends BaseToolInvocation<EditToolParams, ToolResult> {
+class EditToolInvocation extends BaseToolInvocation<
+  EditToolParams,
+  ToolResult
+> {
   constructor(
-    private readonly config: Config, 
+    private readonly config: Config,
     public params: EditToolParams,
   ) {
     super(params);
@@ -155,8 +158,6 @@ class EditToolInvocation extends BaseToolInvocation<EditToolParams, ToolResult> 
   toolLocations(): ToolLocation[] {
     return [{ path: this.params.file_path }];
   }
-
-  
 
   /**
    * Calculates the potential outcome of an edit operation.

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -168,7 +168,7 @@ describe('ReadFileTool', () => {
     it('should return error if file does not exist', async () => {
       const filePath = path.join(tempRootDir, 'nonexistent.txt');
       const params: ReadFileToolParams = { pathHint: filePath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -190,7 +190,7 @@ describe('ReadFileTool', () => {
       const fileContent = 'This is a test file.';
       await fsp.writeFile(filePath, fileContent, 'utf-8');
       const params: ReadFileToolParams = { pathHint: filePath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -205,7 +205,7 @@ describe('ReadFileTool', () => {
       const dirPath = path.join(tempRootDir, 'directory');
       await fsp.mkdir(dirPath);
       const params: ReadFileToolParams = { pathHint: dirPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -228,7 +228,7 @@ describe('ReadFileTool', () => {
       const largeContent = 'x'.repeat(21 * 1024 * 1024);
       await fsp.writeFile(filePath, largeContent, 'utf-8');
       const params: ReadFileToolParams = { pathHint: filePath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -247,7 +247,7 @@ describe('ReadFileTool', () => {
       const fileContent = `Short line\n${longLine}\nAnother short line`;
       await fsp.writeFile(filePath, fileContent, 'utf-8');
       const params: ReadFileToolParams = { pathHint: filePath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -268,14 +268,17 @@ describe('ReadFileTool', () => {
       ]);
       await fsp.writeFile(imagePath, pngHeader);
       const params: ReadFileToolParams = { pathHint: imagePath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
 
       const result = await invocation.execute(abortSignal);
       expect(result.llmContent).toEqual({
-        inlineData: { data: pngHeader.toString('base64'), mimeType: 'image/png' },
+        inlineData: {
+          data: pngHeader.toString('base64'),
+          mimeType: 'image/png',
+        },
       });
       expect(result.returnDisplay).toBe('Read image file: image.png');
     });
@@ -286,14 +289,17 @@ describe('ReadFileTool', () => {
       const pdfHeader = Buffer.from('%PDF-1.4');
       await fsp.writeFile(pdfPath, pdfHeader);
       const params: ReadFileToolParams = { pathHint: pdfPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
 
       const result = await invocation.execute(abortSignal);
       expect(result.llmContent).toEqual({
-        inlineData: { data: pdfHeader.toString('base64'), mimeType: 'application/pdf' },
+        inlineData: {
+          data: pdfHeader.toString('base64'),
+          mimeType: 'application/pdf',
+        },
       });
       expect(result.returnDisplay).toBe('Read pdf file: document.pdf');
     });
@@ -304,7 +310,7 @@ describe('ReadFileTool', () => {
       const binaryData = Buffer.from([0x00, 0xff, 0x00, 0xff]);
       await fsp.writeFile(binPath, binaryData);
       const params: ReadFileToolParams = { pathHint: binPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -321,7 +327,7 @@ describe('ReadFileTool', () => {
       const svgContent = '<svg><circle cx="50" cy="50" r="40"/></svg>';
       await fsp.writeFile(svgPath, svgContent, 'utf-8');
       const params: ReadFileToolParams = { pathHint: svgPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -337,7 +343,7 @@ describe('ReadFileTool', () => {
       const largeContent = '<svg>' + 'x'.repeat(1024 * 1024 + 1) + '</svg>';
       await fsp.writeFile(svgPath, largeContent, 'utf-8');
       const params: ReadFileToolParams = { pathHint: svgPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -355,7 +361,7 @@ describe('ReadFileTool', () => {
       const emptyPath = path.join(tempRootDir, 'empty.txt');
       await fsp.writeFile(emptyPath, '', 'utf-8');
       const params: ReadFileToolParams = { pathHint: emptyPath };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -376,7 +382,7 @@ describe('ReadFileTool', () => {
         offset: 5, // Start from line 6
         limit: 3,
       };
-      const invocation = tool.build(params) as ToolInvocation< 
+      const invocation = tool.build(params) as ToolInvocation<
         ReadFileToolParams,
         ToolResult
       >;
@@ -437,7 +443,7 @@ describe('ReadFileTool', () => {
       });
     });
   });
-  
+
   // This describe block is from HEAD
   describe('workspace boundary validation', () => {
     it('should validate paths are within workspace root', () => {

--- a/packages/core/src/tools/shikiManagerTool.ts
+++ b/packages/core/src/tools/shikiManagerTool.ts
@@ -1,0 +1,471 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ToolErrorType } from './tool-error.js';
+import { Type } from '@google/genai';
+import { BaseTool, Icon, ToolResult } from './tools.js';
+import { Config } from '../config/config.js';
+import { SchemaValidator } from '../utils/schemaValidator.js';
+
+export interface ShikiManagerToolParams {
+  subcommand: string;
+  args?: string[];
+}
+
+interface ShikiManagerResponse {
+  success: boolean;
+  data?: any;
+  error?: string;
+  formattedDisplay?: string;
+}
+
+/**
+ * A tool for managing the Shiki system.
+ */
+export class ShikiManagerTool extends BaseTool<
+  ShikiManagerToolParams,
+  ToolResult
+> {
+  static readonly Name: string = 'shiki_manager_tool';
+  private static readonly DEFAULT_TIMEOUT = 30000; // 30 seconds
+
+  constructor(private readonly config: Config) {
+    super(
+      ShikiManagerTool.Name,
+      'ShikiManager',
+      'A tool to manage the Shiki system, with subcommands: create_task, get_task, list_tasks, list_services',
+      Icon.Hammer,
+      {
+        type: Type.OBJECT,
+        properties: {
+          subcommand: {
+            type: Type.STRING,
+            description:
+              'The subcommand to execute: create_task, get_task, list_tasks, or list_services',
+          },
+          args: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.STRING,
+            },
+            description: 'Arguments for the subcommand',
+          },
+        },
+        required: ['subcommand'],
+      },
+      false, // output is not markdown
+      false, // does not update output
+    );
+  }
+
+  /**
+   * Validates the parameters for the tool.
+   * @param params The parameters to validate.
+   * @returns A string containing the validation error, or null if validation succeeds.
+   */
+  validateToolParams(params: ShikiManagerToolParams): string | null {
+    const errors = SchemaValidator.validate(this.schema.parameters, params);
+    if (errors) {
+      return errors;
+    }
+
+    if (!params.subcommand || !params.subcommand.trim()) {
+      return 'Subcommand cannot be empty or just whitespace.';
+    }
+
+    const validSubcommands = [
+      'create_task',
+      'get_task',
+      'list_tasks',
+      'list_services',
+    ];
+    if (!validSubcommands.includes(params.subcommand)) {
+      return `Invalid subcommand: ${params.subcommand}. Valid subcommands are: ${validSubcommands.join(', ')}`;
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets a description of the tool's operation for logging.
+   * @param params The parameters for the tool.
+   * @returns A string describing the tool's operation.
+   */
+  getDescription(params: ShikiManagerToolParams): string {
+    return `Executing Shiki Manager subcommand: ${params.subcommand}`;
+  }
+
+  /**
+   * Executes the specified subcommand.
+   * @param params The parameters for the tool.
+   * @param signal An AbortSignal to cancel the operation.
+   * @returns A promise that resolves with the subcommand response.
+   */
+  private async executeSubcommand(
+    params: ShikiManagerToolParams,
+    signal: AbortSignal,
+  ): Promise<ShikiManagerResponse> {
+    const { subcommand, args = [] } = params;
+
+    switch (subcommand) {
+      case 'create_task':
+        const prompt = args[0];
+        if (!prompt) {
+          return {
+            success: false,
+            error: 'Missing required argument: prompt',
+          };
+        }
+
+        try {
+          const response = await fetch(
+            `${this.config.getShikiManagerApiUrl()}/api/v1/tasks`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ definition: { prompt } }),
+              signal,
+            },
+          );
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            return {
+              success: false,
+              error: errorData.error || `HTTP error: ${response.status}`,
+            };
+          }
+
+          const data = await response.json();
+          return {
+            success: true,
+            data,
+          };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            success: false,
+            error: `Network error: ${message}`,
+          };
+        }
+
+      case 'get_task':
+        const taskId = args[0];
+        if (!taskId) {
+          return {
+            success: false,
+            error: 'Missing required argument: task_id',
+          };
+        }
+
+        try {
+          const response = await fetch(
+            `${this.config.getShikiManagerApiUrl()}/api/v1/tasks/${taskId}`,
+            {
+              method: 'GET',
+              signal,
+            },
+          );
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            return {
+              success: false,
+              error: errorData.error || `HTTP error: ${response.status}`,
+            };
+          }
+
+          const data = await response.json();
+          return {
+            success: true,
+            data,
+          };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            success: false,
+            error: `Network error: ${message}`,
+          };
+        }
+
+      case 'list_tasks':
+        const isVerbose = args.includes('--verbose');
+        const filteredArgs = args.filter((arg) => arg !== '--verbose');
+
+        try {
+          const response = await fetch(
+            `${this.config.getShikiManagerApiUrl()}/api/v1/tasks`,
+            {
+              method: 'GET',
+              signal,
+            },
+          );
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            return {
+              success: false,
+              error: errorData.error || `HTTP error: ${response.status}`,
+            };
+          }
+
+          const data = await response.json();
+
+          if (isVerbose) {
+            return {
+              success: true,
+              data,
+            };
+          } else {
+            const tableString = this._formatTasksAsTable(data);
+            return {
+              success: true,
+              data,
+              formattedDisplay: tableString,
+            };
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            success: false,
+            error: `Network error: ${message}`,
+          };
+        }
+
+      case 'list_services':
+        try {
+          const serviceType = args[0];
+          const url = serviceType
+            ? `${this.config.getShikiManagerApiUrl()}/api/v1/services?service_type=${serviceType}`
+            : `${this.config.getShikiManagerApiUrl()}/api/v1/services`;
+
+          const response = await fetch(url, {
+            method: 'GET',
+            signal,
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            return {
+              success: false,
+              error: errorData.error || `HTTP error: ${response.status}`,
+            };
+          }
+
+          const data = await response.json();
+          return {
+            success: true,
+            data,
+          };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            success: false,
+            error: `Network error: ${message}`,
+          };
+        }
+
+      default:
+        return {
+          success: false,
+          error: `Unknown subcommand: ${subcommand}`,
+        };
+    }
+  }
+
+  /**
+   * Formats tasks as a formatted table.
+   * @param tasks The array of task objects to format.
+   * @returns A formatted string table.
+   */
+  private _formatTasksAsTable(tasks: any[]): string {
+    if (!tasks || tasks.length === 0) {
+      return 'No tasks found.';
+    }
+
+    const columnWidths = {
+      id: 38,
+      status: 10,
+      createdAt: 21,
+      prompt: 62,
+    };
+
+    let table = '';
+
+    // Top border
+    table +=
+      '┌' +
+      '─'.repeat(columnWidths.id) +
+      '┬' +
+      '─'.repeat(columnWidths.status) +
+      '┬' +
+      '─'.repeat(columnWidths.createdAt) +
+      '┬' +
+      '─'.repeat(columnWidths.prompt) +
+      '┐\n';
+
+    // Header
+    table +=
+      '│ ' +
+      'ID'.padEnd(columnWidths.id - 2) +
+      ' │ ' +
+      'Status'.padEnd(columnWidths.status - 2) +
+      ' │ ' +
+      'Created At'.padEnd(columnWidths.createdAt - 2) +
+      ' │ ' +
+      'Prompt'.padEnd(columnWidths.prompt - 2) +
+      ' │\n';
+
+    // Header separator
+    table +=
+      '├' +
+      '─'.repeat(columnWidths.id) +
+      '┼' +
+      '─'.repeat(columnWidths.status) +
+      '┼' +
+      '─'.repeat(columnWidths.createdAt) +
+      '┼' +
+      '─'.repeat(columnWidths.prompt) +
+      '┤\n';
+
+    // Data rows
+    tasks.forEach((task, index) => {
+      const id = task.id || '';
+      const status = task.status || '';
+      const createdAt = task.created_at
+        ? new Date(task.created_at).toLocaleString('sv')
+        : '';
+      const prompt = task.definition?.prompt || '';
+      const truncatedPrompt =
+        prompt.length > 60 ? prompt.substring(0, 60) + '...' : prompt;
+
+      table +=
+        '│ ' +
+        id.padEnd(columnWidths.id - 2) +
+        ' │ ' +
+        status.padEnd(columnWidths.status - 2) +
+        ' │ ' +
+        createdAt.padEnd(columnWidths.createdAt - 2) +
+        ' │ ' +
+        truncatedPrompt.padEnd(columnWidths.prompt - 2) +
+        ' │\n';
+    });
+
+    // Bottom border
+    table +=
+      '└' +
+      '─'.repeat(columnWidths.id) +
+      '┴' +
+      '─'.repeat(columnWidths.status) +
+      '┴' +
+      '─'.repeat(columnWidths.createdAt) +
+      '┴' +
+      '─'.repeat(columnWidths.prompt) +
+      '┘';
+
+    return table;
+  }
+
+  /**
+   * Executes the tool.
+   * @param params The parameters for the tool.
+   * @param signal An AbortSignal to cancel the process.
+   * @param updateOutput A callback to stream output updates (not used for this tool).
+   * @returns A promise that resolves with the tool's result.
+   */
+  async execute(
+    params: ShikiManagerToolParams,
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    // Validate parameters
+    const validationError = this.validateToolParams(params);
+    if (validationError) {
+      return {
+        llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
+        returnDisplay: `❌ ${validationError}`,
+        error: {
+          message: validationError,
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+      };
+    }
+
+    // Execute the subcommand
+    const response = await this.executeSubcommand(params, signal);
+
+    // Handle execution failure
+    if (!response.success) {
+      const errorMessage = response.error || 'Unknown error occurred';
+      return {
+        llmContent: `Error executing Shiki Manager subcommand: ${errorMessage}`,
+        returnDisplay: `❌ Shiki Manager execution failed: ${errorMessage}`,
+        error: {
+          message: errorMessage,
+          type: ToolErrorType.UNKNOWN,
+        },
+      };
+    }
+
+    // Check if we have a formatted display
+    if (response.formattedDisplay) {
+      return {
+        summary: `Shiki Manager executed: ${params.subcommand}`,
+        llmContent: response.formattedDisplay,
+        returnDisplay: response.formattedDisplay,
+      };
+    }
+
+    // Format the result
+    const result = {
+      subcommand: params.subcommand,
+      args: params.args,
+      data: response.data,
+    };
+
+    // Create a user-friendly summary
+    let returnDisplay = `✅ Shiki Manager executed successfully\n\n`;
+    returnDisplay += `**Subcommand:** ${params.subcommand}\n`;
+    if (params.args && params.args.length > 0) {
+      returnDisplay += `**Arguments:** ${params.args.join(', ')}\n`;
+    }
+    returnDisplay += `\n**Result:**\n${response.data}`;
+
+    return {
+      summary: `Shiki Manager executed: ${params.subcommand}`,
+      llmContent: JSON.stringify(result, null, 2),
+      returnDisplay,
+    };
+  }
+
+  /**
+   * Returns a usage message for the tool.
+   * @returns A string with usage information.
+   */
+  static getUsageMessage(): string {
+    return `
+Shiki Manager Tool Usage:
+
+Available subcommands:
+  - create_task <prompt>     : Create a new task with the given prompt
+  - get_task <task_id>       : Retrieve a task by its ID
+  - list_tasks [--verbose]     : List all available tasks (shows summary by default)
+  - list_services [type]     : List all available services (optionally filtered by type)
+
+Example usage:
+  shiki_manager_tool create_task "Process this data"
+  shiki_manager_tool get_task task123
+  shiki_manager_tool list_tasks
+  shiki_manager_tool list_services
+    `.trim();
+  }
+}


### PR DESCRIPTION
## TLDR

add shikiManagerTool with enhanced list_tasks

## Dive Deeper

Implements the new `shiki_manager_tool` for interacting with the Shiki system.

The `list_tasks` subcommand now features an improved user experience:
- By default, it displays a formatted summary table of tasks (ID, Status, Created At, Prompt).
- A `--verbose` flag is introduced to show the full, raw JSON output for detailed inspection or scripting purposes.

This change makes the default output more intuitive and scannable while retaining full data access via the verbose flag.


