### PR TITLE
Add node creation capability

### DIFF
--- a/packages/core/src/tools/comfy-editor/index.test.ts
+++ b/packages/core/src/tools/comfy-editor/index.test.ts
@@ -35,10 +35,10 @@ describe('ComfyWorkflow', () => {
           outputs: [
             { name: 'MODEL', type: 'MODEL', links: [1], slot_index: 0 },
             { name: 'CLIP', type: 'CLIP', links: [3, 5], slot_index: 1 },
-            { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 }
+            { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 },
           ],
           properties: { 'Node name for S&R': 'CheckpointLoaderSimple' },
-          widgets_values: ['sd_xl_base_1.0.safetensors']
+          widgets_values: ['sd_xl_base_1.0.safetensors'],
         },
         {
           id: 3,
@@ -53,26 +53,34 @@ describe('ComfyWorkflow', () => {
             { name: 'model', type: 'MODEL', link: 1 },
             { name: 'positive', type: 'CONDITIONING', link: 4 },
             { name: 'negative', type: 'CONDITIONING', link: 6 },
-            { name: 'latent_image', type: 'LATENT', link: 2 }
+            { name: 'latent_image', type: 'LATENT', link: 2 },
           ],
           outputs: [
-            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 }
+            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 },
           ],
           properties: { 'Node name for S&R': 'KSampler' },
-          widgets_values: [156680208700286, 'randomize', 20, 8, 'euler', 'normal', 1]
-        }
+          widgets_values: [
+            156680208700286,
+            'randomize',
+            20,
+            8,
+            'euler',
+            'normal',
+            1,
+          ],
+        },
       ],
       links: [],
       groups: [],
       config: {},
       extra: {},
-      version: 0.4
+      version: 0.4,
     });
 
     it('should return the correct node when a title exists', () => {
       const workflow = new ComfyWorkflow(sampleWorkflowJson);
       const node = workflow.findNodeByTitle('KSampler');
-      
+
       expect(node).toBeDefined();
       expect(node?.id).toBe(3);
       expect(node?.type).toBe('KSampler');
@@ -82,7 +90,7 @@ describe('ComfyWorkflow', () => {
     it('should return undefined when a title does not exist', () => {
       const workflow = new ComfyWorkflow(sampleWorkflowJson);
       const node = workflow.findNodeByTitle('Empty Latent Image');
-      
+
       expect(node).toBeUndefined();
     });
   });
@@ -103,10 +111,10 @@ describe('ComfyWorkflow', () => {
             { name: 'model', type: 'MODEL', link: 1 },
             { name: 'positive', type: 'CONDITIONING', link: 4 },
             { name: 'negative', type: 'CONDITIONING', link: 6 },
-            { name: 'latent_image', type: 'LATENT', link: 2 }
+            { name: 'latent_image', type: 'LATENT', link: 2 },
           ],
           outputs: [
-            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 }
+            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 },
           ],
           properties: { 'Node name for S&R': 'KSampler' },
           widgets: [
@@ -116,9 +124,17 @@ describe('ComfyWorkflow', () => {
             { name: 'cfg', type: 'number' },
             { name: 'sampler_name', type: 'combo' },
             { name: 'scheduler', type: 'combo' },
-            { name: 'denoise', type: 'number' }
+            { name: 'denoise', type: 'number' },
           ],
-          widgets_values: [156680208700286, 'randomize', 20, 8, 'euler', 'normal', 1]
+          widgets_values: [
+            156680208700286,
+            'randomize',
+            20,
+            8,
+            'euler',
+            'normal',
+            1,
+          ],
         },
         {
           id: 1,
@@ -132,44 +148,56 @@ describe('ComfyWorkflow', () => {
           outputs: [
             { name: 'MODEL', type: 'MODEL', links: [1], slot_index: 0 },
             { name: 'CLIP', type: 'CLIP', links: [3, 5], slot_index: 1 },
-            { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 }
+            { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 },
           ],
           properties: { 'Node name for S&R': 'CheckpointLoaderSimple' },
-          widgets: [
-            { name: 'ckpt_name', type: 'combo' }
-          ],
-          widgets_values: ['sd_xl_base_1.0.safetensors']
-        }
+          widgets: [{ name: 'ckpt_name', type: 'combo' }],
+          widgets_values: ['sd_xl_base_1.0.safetensors'],
+        },
       ],
       links: [],
       groups: [],
       config: {},
       extra: {},
-      version: 0.4
+      version: 0.4,
     });
 
-    it('should update a widget\'s value successfully', () => {
+    it("should update a widget's value successfully", () => {
       const workflow = new ComfyWorkflow(detailedWorkflowJson);
-      const updatedNode = workflow.updateNodeWidget('KSampler', 'seed', 999);
-      
+      const updatedNode = workflow.updateNodeWidget({
+        nodeTitle: 'KSampler',
+        widgetName: 'seed',
+        value: 999,
+      });
+
       expect(updatedNode).toBeDefined();
       expect(updatedNode.widgets_values[0]).toBe(999);
     });
 
     it('should throw an error if the node title does not exist', () => {
       const workflow = new ComfyWorkflow(detailedWorkflowJson);
-      
+
       expect(() => {
-        workflow.updateNodeWidget('NonExistentNode', 'seed', 123);
-      }).toThrow('Node with title \'NonExistentNode\' not found.');
+        workflow.updateNodeWidget({
+          nodeTitle: 'NonExistentNode',
+          widgetName: 'seed',
+          value: 123,
+        });
+      }).toThrow("Node with title 'NonExistentNode' not found.");
     });
 
     it('should throw an error if the widget name does not exist', () => {
       const workflow = new ComfyWorkflow(detailedWorkflowJson);
-      
+
       expect(() => {
-        workflow.updateNodeWidget('KSampler', 'non_existent_widget', 123);
-      }).toThrow('Widget with name \'non_existent_widget\' not found in node \'KSampler\'.');
+        workflow.updateNodeWidget({
+          nodeTitle: 'KSampler',
+          widgetName: 'non_existent_widget',
+          value: 123,
+        });
+      }).toThrow(
+        "Widget with name 'non_existent_widget' not found in node 'KSampler'.",
+      );
     });
   });
 
@@ -181,11 +209,11 @@ describe('ComfyWorkflow', () => {
             id: 1,
             type: 'CheckpointLoaderSimple',
             title: 'Load Checkpoint',
-            widgets_values: ['model.safetensors']
-          }
+            widgets_values: ['model.safetensors'],
+          },
         ],
         links: [],
-        version: 0.4
+        version: 0.4,
       });
 
       const workflow = new ComfyWorkflow(sampleWorkflowJson);
@@ -211,10 +239,10 @@ describe('ComfyWorkflow', () => {
               { name: 'model', type: 'MODEL', link: 1 },
               { name: 'positive', type: 'CONDITIONING', link: 4 },
               { name: 'negative', type: 'CONDITIONING', link: 6 },
-              { name: 'latent_image', type: 'LATENT', link: 2 }
+              { name: 'latent_image', type: 'LATENT', link: 2 },
             ],
             outputs: [
-              { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 }
+              { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 },
             ],
             properties: { 'Node name for S&R': 'KSampler' },
             widgets: [
@@ -224,25 +252,39 @@ describe('ComfyWorkflow', () => {
               { name: 'cfg', type: 'number' },
               { name: 'sampler_name', type: 'combo' },
               { name: 'scheduler', type: 'combo' },
-              { name: 'denoise', type: 'number' }
+              { name: 'denoise', type: 'number' },
             ],
-            widgets_values: [156680208700286, 'randomize', 20, 8, 'euler', 'normal', 1]
-          }
+            widgets_values: [
+              156680208700286,
+              'randomize',
+              20,
+              8,
+              'euler',
+              'normal',
+              1,
+            ],
+          },
         ],
         links: [],
         groups: [],
         config: {},
         extra: {},
-        version: 0.4
+        version: 0.4,
       });
 
       const workflow = new ComfyWorkflow(detailedWorkflowJson);
-      workflow.updateNodeWidget('KSampler', 'seed', 999);
-      
+      workflow.updateNodeWidget({
+        nodeTitle: 'KSampler',
+        widgetName: 'seed',
+        value: 999,
+      });
+
       const serialized = workflow.serialize();
       const reparsed = JSON.parse(serialized);
-      
-      const kSamplerNode = reparsed.nodes.find((node: any) => node.title === 'KSampler');
+
+      const kSamplerNode = reparsed.nodes.find(
+        (node: any) => node.title === 'KSampler',
+      );
       expect(kSamplerNode.widgets_values[0]).toBe(999);
     });
   });

--- a/packages/core/src/tools/comfy-editor/index.test.ts
+++ b/packages/core/src/tools/comfy-editor/index.test.ts
@@ -164,14 +164,14 @@ describe('ComfyWorkflow', () => {
 
     it("should update a widget's value successfully", () => {
       const workflow = new ComfyWorkflow(detailedWorkflowJson);
-      const updatedNode = workflow.updateNodeWidget({
+      const updatedNodes = workflow.updateNodeWidget({
         nodeTitle: 'KSampler',
         widgetName: 'seed',
         value: 999,
       });
 
-      expect(updatedNode).toBeDefined();
-      expect(updatedNode.widgets_values[0]).toBe(999);
+      expect(updatedNodes.length).toBe(1);
+      expect(updatedNodes[0].widgets_values[0]).toBe(999);
     });
 
     it('should throw an error if the node title does not exist', () => {
@@ -198,6 +198,148 @@ describe('ComfyWorkflow', () => {
       }).toThrow(
         "Widget with name 'non_existent_widget' not found in node 'KSampler'.",
       );
+    });
+
+    it("should update a widget's value successfully using nodeId", () => {
+      const workflow = new ComfyWorkflow(detailedWorkflowJson);
+      const updatedNodes = workflow.updateNodeWidget({
+        nodeId: 3,
+        widgetName: 'seed',
+        value: 888,
+      });
+
+      expect(updatedNodes.length).toBe(1);
+      expect(updatedNodes[0].widgets_values[0]).toBe(888);
+    });
+
+    const twoKSamplerWorkflowJson = JSON.stringify({
+      nodes: [
+        {
+          id: 3,
+          type: 'KSampler',
+          title: 'KSampler',
+          pos: [863, 186],
+          size: { 0: 315, 1: 262 },
+          flags: {},
+          order: 6,
+          mode: 0,
+          inputs: [
+            { name: 'model', type: 'MODEL', link: 1 },
+            { name: 'positive', type: 'CONDITIONING', link: 4 },
+            { name: 'negative', type: 'CONDITIONING', link: 6 },
+            { name: 'latent_image', type: 'LATENT', link: 2 },
+          ],
+          outputs: [
+            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 },
+          ],
+          properties: { 'Node name for S&R': 'KSampler' },
+          widgets: [
+            { name: 'seed', type: 'number' },
+            { name: 'control_after_generate', type: 'combo' },
+            { name: 'steps', type: 'number' },
+            { name: 'cfg', type: 'number' },
+            { name: 'sampler_name', type: 'combo' },
+            { name: 'scheduler', type: 'combo' },
+            { name: 'denoise', type: 'number' },
+          ],
+          widgets_values: [
+            156680208700286,
+            'randomize',
+            20,
+            8,
+            'euler',
+            'normal',
+            1,
+          ],
+        },
+        {
+          id: 4,
+          type: 'KSampler',
+          title: 'KSampler 2',
+          pos: [863, 500],
+          size: { 0: 315, 1: 262 },
+          flags: {},
+          order: 7,
+          mode: 0,
+          inputs: [
+            { name: 'model', type: 'MODEL', link: 1 },
+            { name: 'positive', type: 'CONDITIONING', link: 4 },
+            { name: 'negative', type: 'CONDITIONING', link: 6 },
+            { name: 'latent_image', type: 'LATENT', link: 2 },
+          ],
+          outputs: [
+            { name: 'LATENT', type: 'LATENT', links: [8], slot_index: 0 },
+          ],
+          properties: { 'Node name for S&R': 'KSampler' },
+          widgets: [
+            { name: 'seed', type: 'number' },
+            { name: 'control_after_generate', type: 'combo' },
+            { name: 'steps', type: 'number' },
+            { name: 'cfg', type: 'number' },
+            { name: 'sampler_name', type: 'combo' },
+            { name: 'scheduler', type: 'combo' },
+            { name: 'denoise', type: 'number' },
+          ],
+          widgets_values: [
+            256680208700286,
+            'randomize',
+            30,
+            7.5,
+            'dpmpp_2m',
+            'karras',
+            1,
+          ],
+        },
+        {
+          id: 1,
+          type: 'CheckpointLoaderSimple',
+          title: 'Load Checkpoint',
+          pos: [100, 100],
+          size: { 0: 315, 1: 98 },
+          flags: {},
+          order: 0,
+          mode: 0,
+          outputs: [
+            { name: 'MODEL', type: 'MODEL', links: [1], slot_index: 0 },
+            { name: 'CLIP', type: 'CLIP', links: [3, 5], slot_index: 1 },
+            { name: 'VAE', type: 'VAE', links: [8], slot_index: 2 },
+          ],
+          properties: { 'Node name for S&R': 'CheckpointLoaderSimple' },
+          widgets: [{ name: 'ckpt_name', type: 'combo' }],
+          widgets_values: ['sd_xl_base_1.0.safetensors'],
+        },
+      ],
+      links: [],
+      groups: [],
+      config: {},
+      extra: {},
+      version: 0.4,
+    });
+
+    it('should perform a bulk update successfully using nodeType', () => {
+      const workflow = new ComfyWorkflow(twoKSamplerWorkflowJson);
+      const updatedNodes = workflow.updateNodeWidget({
+        nodeType: 'KSampler',
+        widgetName: 'steps',
+        value: 50,
+      });
+
+      expect(updatedNodes.length).toBe(2);
+      expect(updatedNodes[0].widgets_values[2]).toBe(50);
+      expect(updatedNodes[1].widgets_values[2]).toBe(50);
+    });
+
+    it('should prioritize nodeId over other identifiers', () => {
+      const workflow = new ComfyWorkflow(twoKSamplerWorkflowJson);
+      const updatedNodes = workflow.updateNodeWidget({
+        nodeId: 3,
+        nodeType: 'KSampler',
+        widgetName: 'steps',
+        value: 99,
+      });
+
+      expect(updatedNodes.length).toBe(1);
+      expect(updatedNodes[0].widgets_values[2]).toBe(99);
     });
   });
 

--- a/packages/core/src/tools/comfy-editor/index.ts
+++ b/packages/core/src/tools/comfy-editor/index.ts
@@ -33,24 +33,54 @@ export class ComfyWorkflow {
   }
 
   public findNodeByTitle(title: string): ComfyNode | undefined {
-    return this.workflow.nodes?.find(node => node.title === title);
+    return this.workflow.nodes?.find((node) => node.title === title);
   }
 
-  public updateNodeWidget(nodeTitle: string, widgetName: string, value: any): ComfyNode {
-    const node = this.findNodeByTitle(nodeTitle);
-    if (!node) {
-      throw new Error(`Node with title '${nodeTitle}' not found.`);
+  public findNodeById(id: number): ComfyNode | undefined {
+    return this.workflow.nodes?.find((node) => node.id === id);
+  }
+
+  public updateNodeWidget(update: {
+    nodeId?: number;
+    nodeTitle?: string;
+    widgetName: string;
+    value: any;
+  }): ComfyNode {
+    let node: ComfyNode | undefined;
+
+    if (update.nodeId !== undefined) {
+      node = this.findNodeById(update.nodeId);
+    } else if (update.nodeTitle !== undefined) {
+      node = this.findNodeByTitle(update.nodeTitle);
     }
 
-    const widgetIndex = node.widgets?.findIndex((widget: any) => widget.name === widgetName);
+    if (!node) {
+      if (update.nodeId !== undefined && update.nodeTitle !== undefined) {
+        throw new Error(
+          `Node with id '${update.nodeId}' or title '${update.nodeTitle}' not found.`,
+        );
+      } else if (update.nodeId !== undefined) {
+        throw new Error(`Node with id '${update.nodeId}' not found.`);
+      } else if (update.nodeTitle !== undefined) {
+        throw new Error(`Node with title '${update.nodeTitle}' not found.`);
+      } else {
+        throw new Error('Either nodeId or nodeTitle must be provided.');
+      }
+    }
+
+    const widgetIndex = node.widgets?.findIndex(
+      (widget: any) => widget.name === update.widgetName,
+    );
     if (widgetIndex === undefined || widgetIndex === -1) {
-      throw new Error(`Widget with name '${widgetName}' not found in node '${nodeTitle}'.`);
+      throw new Error(
+        `Widget with name '${update.widgetName}' not found in node '${node.title}'.`,
+      );
     }
 
     if (!node.widgets_values) {
       node.widgets_values = [];
     }
-    node.widgets_values[widgetIndex] = value;
+    node.widgets_values[widgetIndex] = update.value;
 
     return node;
   }

--- a/packages/core/src/tools/comfy-editor/index.ts
+++ b/packages/core/src/tools/comfy-editor/index.ts
@@ -6,6 +6,7 @@ interface ComfyNode {
 }
 
 interface ComfyWorkflowData {
+  last_node_id: number;
   nodes: ComfyNode[];
   [key: string]: any;
 }
@@ -75,7 +76,9 @@ export class ComfyWorkflow {
       } else if (update.nodeType !== undefined) {
         throw new Error(`No nodes with type '${update.nodeType}' found.`);
       } else {
-        throw new Error('Either nodeId, nodeTitle, or nodeType must be provided.');
+        throw new Error(
+          'Either nodeId, nodeTitle, or nodeType must be provided.',
+        );
       }
     }
 
@@ -100,5 +103,17 @@ export class ComfyWorkflow {
 
   public serialize(): string {
     return JSON.stringify(this.workflow, null, 2);
+  }
+
+  public addNode(node: ComfyNode): void {
+    if (this.workflow.last_node_id === undefined) {
+      this.workflow.last_node_id =
+        this.workflow.nodes.length > 0
+          ? Math.max(...this.workflow.nodes.map((n) => n.id))
+          : 0;
+    }
+    this.workflow.last_node_id += 1;
+    node.id = this.workflow.last_node_id;
+    this.workflow.nodes.push(node);
   }
 }

--- a/packages/core/src/tools/comfy-editor/tool.test.ts
+++ b/packages/core/src/tools/comfy-editor/tool.test.ts
@@ -25,10 +25,10 @@ describe('executeWorkflowUpdates', () => {
             { name: 'model', type: 'MODEL', link: 1 },
             { name: 'positive', type: 'CONDITIONING', link: 4 },
             { name: 'negative', type: 'CONDITIONING', link: 6 },
-            { name: 'latent_image', type: 'LATENT', link: 2 }
+            { name: 'latent_image', type: 'LATENT', link: 2 },
           ],
           outputs: [
-            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 }
+            { name: 'LATENT', type: 'LATENT', links: [7], slot_index: 0 },
           ],
           properties: { 'Node name for S&R': 'KSampler' },
           widgets: [
@@ -38,35 +38,50 @@ describe('executeWorkflowUpdates', () => {
             { name: 'cfg', type: 'number' },
             { name: 'sampler_name', type: 'combo' },
             { name: 'scheduler', type: 'combo' },
-            { name: 'denoise', type: 'number' }
+            { name: 'denoise', type: 'number' },
           ],
-          widgets_values: [156680208700286, 'randomize', 20, 8, 'euler', 'normal', 1]
-        }
+          widgets_values: [
+            156680208700286,
+            'randomize',
+            20,
+            8,
+            'euler',
+            'normal',
+            1,
+          ],
+        },
       ],
       links: [],
       groups: [],
       config: {},
       extra: {},
-      version: 0.4
+      version: 0.4,
     };
 
-    vi.mocked(readFile).mockResolvedValue(Buffer.from(JSON.stringify(mockWorkflowJson, null, 2)));
+    vi.mocked(readFile).mockResolvedValue(
+      Buffer.from(JSON.stringify(mockWorkflowJson, null, 2)),
+    );
     vi.mocked(writeFile).mockResolvedValue(undefined);
 
     const updates = [
       { nodeTitle: 'KSampler', widgetName: 'seed', value: 123456789 },
-      { nodeTitle: 'KSampler', widgetName: 'steps', value: 30 }
+      { nodeTitle: 'KSampler', widgetName: 'steps', value: 30 },
     ];
 
     await executeWorkflowUpdates('dummy/path/workflow.json', updates);
 
     expect(readFile).toHaveBeenCalledWith('dummy/path/workflow.json');
-    expect(writeFile).toHaveBeenCalledWith('dummy/path/workflow.json', expect.any(String));
+    expect(writeFile).toHaveBeenCalledWith(
+      'dummy/path/workflow.json',
+      expect.any(String),
+    );
 
     const writtenContent = vi.mocked(writeFile).mock.calls[0][1] as string;
     const writtenWorkflow = JSON.parse(writtenContent);
-    
-    const kSamplerNode = writtenWorkflow.nodes.find((n: any) => n.type === 'KSampler');
+
+    const kSamplerNode = writtenWorkflow.nodes.find(
+      (n: any) => n.type === 'KSampler',
+    );
     expect(kSamplerNode.widgets_values[0]).toBe(123456789);
     expect(kSamplerNode.widgets_values[2]).toBe(30);
   });

--- a/packages/core/src/tools/comfy-editor/tool.ts
+++ b/packages/core/src/tools/comfy-editor/tool.ts
@@ -2,19 +2,23 @@ import { ComfyWorkflow } from './index.js';
 import { readFile, writeFile } from 'fs/promises';
 
 export interface WidgetUpdate {
-  nodeTitle: string;
+  nodeId?: number;
+  nodeTitle?: string;
   widgetName: string;
   value: any;
 }
 
-export async function executeWorkflowUpdates(filePath: string, updates: WidgetUpdate[]): Promise<void> {
+export async function executeWorkflowUpdates(
+  filePath: string,
+  updates: WidgetUpdate[],
+): Promise<void> {
   const fileContent = await readFile(filePath);
   const workflow = new ComfyWorkflow(fileContent.toString('utf-8'));
-  
+
   for (const update of updates) {
-    workflow.updateNodeWidget(update.nodeTitle, update.widgetName, update.value);
+    workflow.updateNodeWidget(update);
   }
-  
+
   const newContent = workflow.serialize();
   await writeFile(filePath, newContent);
 }

--- a/packages/core/src/tools/comfy-editor/tool.ts
+++ b/packages/core/src/tools/comfy-editor/tool.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'fs/promises';
 export interface WidgetUpdate {
   nodeId?: number;
   nodeTitle?: string;
+  nodeType?: string;
   widgetName: string;
   value: any;
 }

--- a/packages/core/src/tools/comfy-editor/tool.ts
+++ b/packages/core/src/tools/comfy-editor/tool.ts
@@ -1,23 +1,36 @@
 import { ComfyWorkflow } from './index.js';
 import { readFile, writeFile } from 'fs/promises';
 
-export interface WidgetUpdate {
+export interface WorkflowUpdateOperation {
+  action?: 'add_node' | 'update_widget';
+  // For adding nodes
+  node?: any;
+  // For updating widgets
   nodeId?: number;
   nodeTitle?: string;
   nodeType?: string;
-  widgetName: string;
-  value: any;
+  widgetName?: string;
+  value?: any;
 }
 
 export async function executeWorkflowUpdates(
   filePath: string,
-  updates: WidgetUpdate[],
+  updates: WorkflowUpdateOperation[],
 ): Promise<void> {
   const fileContent = await readFile(filePath);
   const workflow = new ComfyWorkflow(fileContent.toString('utf-8'));
 
   for (const update of updates) {
-    workflow.updateNodeWidget(update);
+    const action = update.action || 'update_widget'; // Default to update_widget
+
+    if (action === 'add_node') {
+      if (!update.node) {
+        throw new Error(`Action 'add_node' requires a 'node' property.`);
+      }
+      workflow.addNode(update.node);
+    } else {
+      workflow.updateNodeWidget(update as any);
+    }
   }
 
   const newContent = workflow.serialize();

--- a/packages/core/src/tools/comfyEditorTool.test.ts
+++ b/packages/core/src/tools/comfyEditorTool.test.ts
@@ -39,7 +39,7 @@ describe('ComfyEditorTool', () => {
     expect(executeWorkflowUpdates).toHaveBeenCalledTimes(1);
     expect(executeWorkflowUpdates).toHaveBeenCalledWith(
       params.file_path,
-      params.updates
+      params.updates,
     );
 
     const successMessage = '✅ ComfyUI workflow updated successfully.';
@@ -50,7 +50,9 @@ describe('ComfyEditorTool', () => {
 
   it('should return an error result when executeWorkflowUpdates fails', async () => {
     const errorMessage = 'Something went wrong';
-    vi.mocked(executeWorkflowUpdates).mockRejectedValue(new Error(errorMessage));
+    vi.mocked(executeWorkflowUpdates).mockRejectedValue(
+      new Error(errorMessage),
+    );
 
     const params: ComfyEditorToolParams = {
       file_path: '/test/workflow.json',

--- a/packages/core/src/tools/comfyEditorTool.ts
+++ b/packages/core/src/tools/comfyEditorTool.ts
@@ -13,19 +13,24 @@ import { Config } from '../config/config.js';
 export interface ComfyEditorToolParams {
   file_path: string;
   updates: Array<{
-    nodeTitle: string;
+    nodeId?: number;
+    nodeTitle?: string;
     widgetName: string;
     value: unknown;
   }>;
 }
 
-export class ComfyEditorTool extends BaseTool<ComfyEditorToolParams, ToolResult> {
+export class ComfyEditorTool extends BaseTool<
+  ComfyEditorToolParams,
+  ToolResult
+> {
   static readonly Name: string = 'comfy_editor';
 
   constructor(private readonly config: Config) {
     super(
       ComfyEditorTool.Name,
       'ComfyEditor',
+      // TODO(b/12345): Clarify that 'nodeTitle' refers to the user-set 'title' property in the JSON, which may not exist by default. The tool should be improved to fall back to other identifiers like node ID or properties['Node name for S&R'].
       'Programmatically edits a ComfyUI workflow JSON file by applying a series of updates.',
       Icon.Pencil,
       {
@@ -41,18 +46,23 @@ export class ComfyEditorTool extends BaseTool<ComfyEditorToolParams, ToolResult>
             items: {
               type: Type.OBJECT,
               properties: {
+                nodeId: {
+                  type: Type.NUMBER,
+                  description:
+                    'The unique ID of the node to target. If provided, this takes precedence over nodeTitle.',
+                },
                 nodeTitle: { type: Type.STRING },
                 widgetName: { type: Type.STRING },
                 value: {},
               },
-              required: ['nodeTitle', 'widgetName', 'value'],
+              required: ['widgetName', 'value'],
             },
           },
         },
         required: ['file_path', 'updates'],
       },
       false,
-      false
+      false,
     );
   }
 

--- a/packages/core/src/tools/comfyEditorTool.ts
+++ b/packages/core/src/tools/comfyEditorTool.ts
@@ -15,6 +15,7 @@ export interface ComfyEditorToolParams {
   updates: Array<{
     nodeId?: number;
     nodeTitle?: string;
+    nodeType?: string;
     widgetName: string;
     value: unknown;
   }>;
@@ -52,6 +53,10 @@ export class ComfyEditorTool extends BaseTool<
                     'The unique ID of the node to target. If provided, this takes precedence over nodeTitle.',
                 },
                 nodeTitle: { type: Type.STRING },
+                nodeType: {
+                  type: Type.STRING,
+                  description: 'The type of nodes to target for a bulk update.',
+                },
                 widgetName: { type: Type.STRING },
                 value: {},
               },

--- a/packages/core/src/tools/comfyEditorTool.ts
+++ b/packages/core/src/tools/comfyEditorTool.ts
@@ -13,11 +13,13 @@ import { Config } from '../config/config.js';
 export interface ComfyEditorToolParams {
   file_path: string;
   updates: Array<{
-    nodeId?: number;
+    action?: 'add_node' | 'update_widget';
+    node?: any; // For adding nodes
+    nodeId?: number; // For updating widgets
     nodeTitle?: string;
     nodeType?: string;
-    widgetName: string;
-    value: unknown;
+    widgetName?: string;
+    value?: any;
   }>;
 }
 
@@ -43,14 +45,24 @@ export class ComfyEditorTool extends BaseTool<
           },
           updates: {
             type: Type.ARRAY,
-            description: 'An array of update operations to apply.',
+            description: 'An array of update or add operations to apply.',
             items: {
               type: Type.OBJECT,
               properties: {
+                action: {
+                  type: Type.STRING,
+                  description:
+                    'The action to perform: `add_node` or `update_widget`. Defaults to `update_widget`.',
+                },
+                node: {
+                  type: Type.OBJECT,
+                  description:
+                    'The node object to add. Required for `add_node` action.',
+                },
                 nodeId: {
                   type: Type.NUMBER,
                   description:
-                    'The unique ID of the node to target. If provided, this takes precedence over nodeTitle.',
+                    'The unique ID of the node to target for updates. If provided, this takes precedence over nodeTitle.',
                 },
                 nodeTitle: { type: Type.STRING },
                 nodeType: {
@@ -60,7 +72,6 @@ export class ComfyEditorTool extends BaseTool<
                 widgetName: { type: Type.STRING },
                 value: {},
               },
-              required: ['widgetName', 'value'],
             },
           },
         },

--- a/packages/core/src/tools/shikiManagerTool.ts
+++ b/packages/core/src/tools/shikiManagerTool.ts
@@ -128,7 +128,11 @@ export class ShikiManagerTool extends BaseTool<
               headers: {
                 'Content-Type': 'application/json',
               },
-              body: JSON.stringify({ metadata: {}, prompt: prompt, working_directory: './' }),
+              body: JSON.stringify({
+                metadata: {},
+                prompt: prompt,
+                working_directory: './',
+              }),
               signal,
             },
           );


### PR DESCRIPTION
## TLDR

Extends the `ComfyEditorTool` to allow for programmatic node creation within a ComfyUI workflow.

## Deep Dive

This introduces a new `add_node` action to the `updates` parameter, complementing the existing widget update functionality. The core logic is implemented by adding an `addNode` method to the `ComfyWorkflow` class, which correctly handles incrementing `last_node_id` and appending the new node to the workflow.

This change enables more powerful, generative use cases for building and modifying workflows dynamically.