### PR TITLE
feat(core): implement websocket shiki-tool

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -35,6 +35,7 @@ import { ClaudeCodeTool } from '../tools/claudeCodeTool.js';
 import { GitTool } from '../tools/gitTool.js';
 import { GitHubTool } from '../tools/githubTool.js';
 import { ShikiManagerTool } from '../tools/shikiManagerTool.js';
+import { ShikiTool } from '../tools/shikiTool.js';
 import { ComfyEditorTool } from '../tools/comfyEditorTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
@@ -786,7 +787,7 @@ export class Config {
     registerCoreTool(ClaudeCodeTool, this);
     registerCoreTool(GitTool, this);
     registerCoreTool(GitHubTool, this);
-    registerCoreTool(ShikiManagerTool, this);
+    registerCoreTool(ShikiTool, this);
     registerCoreTool(ComfyEditorTool, this);
 
     await registry.discoverAllTools();

--- a/packages/core/src/tools/shikiManagerTool.ts
+++ b/packages/core/src/tools/shikiManagerTool.ts
@@ -24,6 +24,7 @@ interface ShikiManagerResponse {
 
 /**
  * A tool for managing the Shiki system.
+ * @deprecated Use ShikiTool instead. This tool is a low-level wrapper.
  */
 export class ShikiManagerTool extends BaseTool<
   ShikiManagerToolParams,

--- a/packages/core/src/tools/shikiTool.test.ts
+++ b/packages/core/src/tools/shikiTool.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="vitest/globals" />
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ShikiTool, Task } from './shikiTool.js';
+import { Config } from '../config/config.js';
+import { ShikiManagerTool } from './shikiManagerTool.js';
+import { ToolResult } from './tools.js';
+import WebSocket from 'ws';
+
+// Mock dependencies
+vi.mock('../config/config.js');
+vi.mock('./shikiManagerTool.js');
+vi.mock('ws');
+
+describe('ShikiTool', () => {
+  let config: Config;
+  let shikiTool: ShikiTool;
+  let mockShikiManagerTool: ShikiManagerTool;
+  let mockUpdateOutput: (output: string) => void;
+
+  const mockTaskData = {
+    id: 'task-123',
+    status: 'Pending',
+    definition: { prompt: 'Test prompt' },
+    created_at: new Date().toISOString(),
+    result: null,
+  };
+
+  // Helper to create a valid ToolResult mock
+  const createMockToolResult = (data: any): ToolResult => ({
+    llmContent: JSON.stringify({ data }),
+    returnDisplay: 'Success',
+    summary: 'Successful execution',
+  });
+
+  beforeEach(() => {
+    config = new Config({} as any); // Provide dummy arg to constructor
+    vi.spyOn(config, 'getShikiManagerApiUrl').mockReturnValue('http://localhost:8080');
+    
+    shikiTool = new ShikiTool(config);
+    mockShikiManagerTool = (shikiTool as any).shikiManagerTool;
+    mockUpdateOutput = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    shikiTool.closeAllSubscriptions();
+  });
+
+  describe('Synchronous Subcommands', () => {
+    it('list_tasks should call shikiManagerTool and format the result', async () => {
+      const mockApiResponse = createMockToolResult([mockTaskData]);
+      vi.spyOn(mockShikiManagerTool, 'execute').mockResolvedValue(mockApiResponse);
+
+      const result = await shikiTool.execute({ subcommand: 'list_tasks' }, new AbortController().signal);
+
+      expect(mockShikiManagerTool.execute).toHaveBeenCalledWith(
+        { subcommand: 'list_tasks', args: ['--verbose'] },
+        expect.any(AbortSignal)
+      );
+      
+      const expectedTasks: Task[] = [{
+        id: 'task-123',
+        status: 'Pending',
+        prompt: 'Test prompt',
+        createdAt: mockTaskData.created_at,
+        result: null,
+      }];
+      expect(JSON.parse(result.llmContent as string)).toEqual(expectedTasks);
+    });
+
+    it('get_task should call shikiManagerTool and format the result', async () => {
+      const mockApiResponse = createMockToolResult(mockTaskData);
+      vi.spyOn(mockShikiManagerTool, 'execute').mockResolvedValue(mockApiResponse);
+
+      const result = await shikiTool.execute({ subcommand: 'get_task', taskId: 'task-123' }, new AbortController().signal);
+
+      expect(mockShikiManagerTool.execute).toHaveBeenCalledWith(
+        { subcommand: 'get_task', args: ['task-123'] },
+        expect.any(AbortSignal)
+      );
+
+      const expectedTask: Task = {
+        id: 'task-123',
+        status: 'Pending',
+        prompt: 'Test prompt',
+        createdAt: mockTaskData.created_at,
+        result: null,
+      };
+      expect(JSON.parse(result.llmContent as string)).toEqual(expectedTask);
+    });
+  });
+
+  describe('create_task and WebSocket logic', () => {
+    let mockWsInstance: WebSocket;
+    const mockWsEvents: { [key: string]: (...args: any[]) => void } = {};
+
+    beforeEach(() => {
+      mockWsInstance = {
+        on: vi.fn((event, cb) => { mockWsEvents[event] = cb; }),
+        close: vi.fn(),
+        readyState: WebSocket.OPEN,
+      } as unknown as WebSocket;
+
+      (WebSocket as any).mockImplementation(() => mockWsInstance);
+
+      const mockApiResponse = createMockToolResult(mockTaskData);
+      vi.spyOn(mockShikiManagerTool, 'execute').mockResolvedValue(mockApiResponse);
+    });
+
+    it('create_task should call shikiManagerTool and initiate a WebSocket connection', async () => {
+      await shikiTool.execute(
+        { subcommand: 'create_task', prompt: 'Test prompt' }, 
+        new AbortController().signal, 
+        mockUpdateOutput
+      );
+
+      expect(mockShikiManagerTool.execute).toHaveBeenCalledWith(
+        { subcommand: 'create_task', args: ['Test prompt'] },
+        expect.any(AbortSignal)
+      );
+
+      expect(WebSocket).toHaveBeenCalledWith('ws://localhost:8080/api/v1/tasks/task-123/ws');
+      expect(mockUpdateOutput).toHaveBeenCalledWith('✅ Task created with ID: task-123');
+    });
+
+    it('should handle WebSocket open event', async () => {
+      await shikiTool.execute({ subcommand: 'create_task', prompt: 'Test prompt' }, new AbortController().signal, mockUpdateOutput);
+      mockWsEvents.open();
+      expect(mockUpdateOutput).toHaveBeenCalledWith('[WS] 🔌 Connection established for task task-123. Waiting for updates...');
+    });
+
+    it('should handle WebSocket message event', async () => {
+      await shikiTool.execute({ subcommand: 'create_task', prompt: 'Test prompt' }, new AbortController().signal, mockUpdateOutput);
+      const updateMessage = JSON.stringify({ status: 'InProgress' });
+      mockWsEvents.message(updateMessage);
+      expect(mockUpdateOutput).toHaveBeenCalledWith('[WS] 🔄 Task task-123 status: InProgress');
+    });
+
+    it('should handle WebSocket error event', async () => {
+      await shikiTool.execute({ subcommand: 'create_task', prompt: 'Test prompt' }, new AbortController().signal, mockUpdateOutput);
+      const error = new Error('Connection failed');
+      mockWsEvents.error(error);
+      expect(mockUpdateOutput).toHaveBeenCalledWith('[WS] ❌ Error for task task-123: Connection failed');
+      expect((shikiTool as any).subscriptions.has('task-123')).toBe(false);
+    });
+
+    it('should handle WebSocket close event', async () => {
+      await shikiTool.execute({ subcommand: 'create_task', prompt: 'Test prompt' }, new AbortController().signal, mockUpdateOutput);
+      mockWsEvents.close(1000, 'Normal closure');
+      expect(mockUpdateOutput).toHaveBeenCalledWith('[WS] 🔌 Connection closed for task task-123. Code: 1000, Reason: Normal closure');
+      expect((shikiTool as any).subscriptions.has('task-123')).toBe(false);
+    });
+
+    it('closeAllSubscriptions should close any open WebSockets', async () => {
+      await shikiTool.execute({ subcommand: 'create_task', prompt: 'Test prompt' }, new AbortController().signal);
+      expect((shikiTool as any).subscriptions.has('task-123')).toBe(true);
+
+      shikiTool.closeAllSubscriptions();
+
+      expect(mockWsInstance.close).toHaveBeenCalled();
+      expect((shikiTool as any).subscriptions.has('task-123')).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/tools/shikiTool.ts
+++ b/packages/core/src/tools/shikiTool.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ToolErrorType } from './tool-error.js';
+import { Type } from '@google/genai';
+import { BaseTool, Icon, ToolResult } from './tools.js';
+import { Config } from '../config/config.js';
+import { SchemaValidator } from '../utils/schemaValidator.js';
+import { ShikiManagerTool } from './shikiManagerTool.js';
+import WebSocket from 'ws';
+
+export interface Task {
+  id: string;
+  status: string; // "Pending", "InProgress", "Completed", "Failed"
+  prompt: string;
+  result?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface ShikiToolParams {
+  subcommand: 'create_task' | 'get_task' | 'list_tasks';
+  prompt?: string;
+  taskId?: string;
+}
+
+/**
+ * A high-level tool to interact with the Shiki system.
+ * Handles asynchronous communication via WebSockets internally.
+ */
+export class ShikiTool extends BaseTool<ShikiToolParams, ToolResult> {
+  static readonly Name: string = 'shiki_tool';
+  private shikiManagerTool: ShikiManagerTool;
+  private subscriptions = new Map<string, WebSocket>();
+
+  constructor(private readonly config: Config) {
+    super(
+      ShikiTool.Name,
+      'Shiki',
+      'A high-level tool to create and manage tasks in the Shiki system.',
+      Icon.Hammer, // Corrected Icon
+      {
+        type: Type.OBJECT,
+        properties: {
+          subcommand: {
+            type: Type.STRING,
+            description: 'The subcommand to execute: create_task, get_task, list_tasks',
+            enum: ['create_task', 'get_task', 'list_tasks'],
+          },
+          prompt: {
+            type: Type.STRING,
+            description: 'The prompt for creating a new task. Required for `create_task`.',
+          },
+          taskId: {
+            type: Type.STRING,
+            description: 'The ID of the task to get. Required for `get_task`.',
+          },
+        },
+        required: ['subcommand'],
+      },
+      false,
+      true // canUpdateOutput = true
+    );
+
+    this.shikiManagerTool = new ShikiManagerTool(this.config);
+  }
+
+  validateToolParams(params: ShikiToolParams): string | null {
+    const errors = SchemaValidator.validate(this.schema.parameters, params);
+    if (errors) {
+      return errors;
+    }
+
+    switch (params.subcommand) {
+      case 'create_task':
+        if (!params.prompt) {
+          return 'Missing required parameter: prompt';
+        }
+        break;
+      case 'get_task':
+        if (!params.taskId) {
+          return 'Missing required parameter: taskId';
+        }
+        break;
+      case 'list_tasks':
+        break;
+      default:
+        return `Invalid subcommand: ${params.subcommand}`;
+    }
+
+    return null;
+  }
+
+  getDescription(params: ShikiToolParams): string {
+    if (params.subcommand === 'create_task') {
+      return `Creating Shiki task with prompt: "${params.prompt?.substring(0, 50)}..."`;
+    }
+    return `Executing Shiki command: ${params.subcommand}`;
+  }
+
+  private toApiTask(data: any): Task {
+    return {
+      id: data.id,
+      status: data.status,
+      prompt: data.definition?.prompt || '',
+      createdAt: data.created_at,
+      result: data.result,
+    };
+  }
+
+  closeAllSubscriptions() {
+    for (const [taskId, ws] of this.subscriptions.entries()) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.close();
+      }
+      this.subscriptions.delete(taskId);
+    }
+  }
+
+  async execute(
+    params: ShikiToolParams,
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void
+  ): Promise<ToolResult> {
+    const validationError = this.validateToolParams(params);
+    if (validationError) {
+      return {
+        error: {
+          message: validationError,
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent: validationError,
+        returnDisplay: `❌ Error: ${validationError}`,
+      };
+    }
+
+    try {
+      switch (params.subcommand) {
+        case 'list_tasks': {
+          const result = await this.shikiManagerTool.execute(
+            { subcommand: 'list_tasks', args: ['--verbose'] },
+            signal
+          );
+
+          if (result.error || !result.llmContent) {
+            throw new Error(result.error?.message || 'Failed to list tasks');
+          }
+          
+          const tasks = JSON.parse(result.llmContent as string).data.map(this.toApiTask);
+          const llmContent = JSON.stringify(tasks, null, 2);
+          return {
+            summary: `Found ${tasks.length} tasks.`,
+            llmContent,
+            returnDisplay: `Found ${tasks.length} tasks.`,
+          };
+        }
+
+        case 'get_task': {
+          const result = await this.shikiManagerTool.execute(
+            { subcommand: 'get_task', args: [params.taskId!] },
+            signal
+          );
+
+          if (result.error || !result.llmContent) {
+            throw new Error(result.error?.message || 'Failed to get task');
+          }
+
+          const task = this.toApiTask(JSON.parse(result.llmContent as string).data);
+          const llmContent = JSON.stringify(task, null, 2);
+          return {
+            summary: `Fetched task ${task.id}`,
+            llmContent,
+            returnDisplay: `Fetched task ${task.id}`,
+          };
+        }
+
+        case 'create_task': {
+          updateOutput?.('⏳ Task creation initiated...');
+          const result = await this.shikiManagerTool.execute(
+            { subcommand: 'create_task', args: [params.prompt!] },
+            signal
+          );
+
+          if (result.error || !result.llmContent) {
+            throw new Error(result.error?.message || 'Failed to create task');
+          }
+          
+          const task = this.toApiTask(JSON.parse(result.llmContent as string).data);
+          updateOutput?.(`✅ Task created with ID: ${task.id}`);
+
+          // --- WebSocket Implementation ---
+          const wsUrl = this.config.getShikiManagerApiUrl().replace(/^http/, 'ws') + `/api/v1/tasks/${task.id}/ws`;
+          const ws = new WebSocket(wsUrl);
+          this.subscriptions.set(task.id, ws);
+
+          ws.on('open', () => {
+            updateOutput?.(`[WS] 🔌 Connection established for task ${task.id}. Waiting for updates...`);
+          });
+
+          ws.on('message', (data) => {
+            try {
+              const message = JSON.parse(data.toString());
+              if (message.status) {
+                 updateOutput?.(`[WS] 🔄 Task ${task.id} status: ${message.status}`);
+              }
+              if (message.result) {
+                updateOutput?.(`[WS] ✨ Task ${task.id} result: ${JSON.stringify(message.result)}`);
+              }
+            } catch (e) {
+              updateOutput?.(`[WS] Received raw message: ${data.toString()}`);
+            }
+          });
+
+          ws.on('error', (error) => {
+            updateOutput?.(`[WS] ❌ Error for task ${task.id}: ${error.message}`);
+            this.subscriptions.delete(task.id);
+          });
+
+          ws.on('close', (code, reason) => {
+            updateOutput?.(`[WS] 🔌 Connection closed for task ${task.id}. Code: ${code}, Reason: ${reason.toString()}`);
+            this.subscriptions.delete(task.id);
+          });
+          
+          const llmContent = JSON.stringify(task, null, 2);
+          return {
+            summary: `Created task ${task.id}`,
+            llmContent,
+            returnDisplay: `Created task ${task.id}`,
+          };
+        }
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        error: { message, type: ToolErrorType.UNHANDLED_EXCEPTION },
+        llmContent: message,
+        returnDisplay: `❌ Error: ${message}`,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## TLDR

Implements a new high-level `ShikiTool` for managing asynchronous tasks within the Shiki system.

## Dive Deeper

This new tool provides a robust, user-friendly interface that leverages WebSockets to deliver real-time task status updates (e.g., 'InProgress', 'Completed'), eliminating the need for polling and improving user experience.

The implementation includes:
- A new `ShikiTool` class that encapsulates task creation and WebSocket subscription logic.
- A comprehensive test suite using mocks to ensure both synchronous and asynchronous functionalities are reliable.
- Integration into the core tool registry, replacing the previous low-level `shikiManagerTool`.
- Deprecation of the old `shikiManagerTool`.

