### PR TITLE
Refactor ClaudeCodeTool to use BaseDeclarativeTool

### DIFF
--- a/packages/core/src/tools/claudeCodeTool.ts
+++ b/packages/core/src/tools/claudeCodeTool.ts
@@ -8,7 +8,14 @@ import { spawn, ChildProcess } from 'child_process';
 import os from 'os';
 import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
-import { BaseTool, Icon, ToolResult } from './tools.js';
+import {
+  BaseDeclarativeTool,
+  Icon,
+  ToolResult,
+  ToolInvocation,
+  ToolLocation,
+  ToolCallConfirmationDetails, // Added for shouldConfirmExecute return type
+} from './tools.js';
 import { Config } from '../config/config.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 
@@ -39,114 +46,94 @@ export interface ClaudeCodeRawOutput {
 export type ParsedClaudeOutput = ClaudeCodeSuccessOutput | ClaudeCodeRawOutput;
 
 /**
- * A tool for interacting with the Claude Code CLI.
+ * Represents an invocation of the Claude Code tool.
  */
-export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
-  static readonly Name: string = 'claude_code';
-  private static readonly DEFAULT_TIMEOUT = 1200000; // 20 minutes
-  private static readonly MAX_TIMEOUT = 6000000; // 60 minutes
+class ClaudeCodeToolInvocation
+  implements ToolInvocation<ClaudeCodeToolParams, ToolResult>
+{
+  constructor(
+    public readonly params: ClaudeCodeToolParams,
+    private readonly config: Config,
+  ) {}
 
-  constructor(private readonly config: Config) {
-    super(
-      ClaudeCodeTool.Name,
-      'ClaudeCode',
-      'Executes a prompt using the Claude Code CLI to perform complex code analysis, generation, and manipulation.',
-      Icon.Terminal,
-      {
-        type: Type.OBJECT,
-        properties: {
-          prompt: {
-            type: Type.STRING,
-            description: `About the prompt argument for the claude_code tool
-
-* Purpose: The prompt argument is a string that describes the specific task or instruction you want the 
-  Claude Code CLI to execute. This is how you communicate the objective that the Claude Code CLI should
-  achieve, leveraging its internal tools (e.g., Bash, Read, Write, etc.).
-
-* Nature of Content:
-    * Instructions and Tasks: The prompt should contain concrete commands for the Claude Code CLI, such as
-      "Fix the bug in this file," "Refactor this module," or "Generate tests for this feature."
-    * Context Provision: If necessary, include additional context required for the task (e.g., "This code
-      is part of the authentication logic," "This function processes user input").
-    * File Path References: If you want operations to be performed on specific files or directories, refer 
-      to their file paths within the \`prompt\` (e.g., "Optimize the calculateSum function in
-      src/utils/helper.ts").
-
-* Important Notes (to avoid misunderstanding):
-    * Not Direct File Content: You do not directly paste file content into the prompt argument. The
-      Claude Code CLI will, based on the instructions given in the prompt, read relevant files itself
-      using its Read tool or Bash tool (e.g., cat command) if necessary.
-    * Instruction for Claude Code CLI: It functions purely as an "instruction manual" for Claude Code
-      CLI, which is another AI agent.
-
-* Good \`prompt\` examples:
-    * "Fix the memory leak in 'src/data_processor.ts' related to the 'cache' object. Focus on lines 
-      120-150."
-    * "Refactor the 'UserAuthService' class in 'packages/cli/src/services/auth.ts' to use functional 
-      components instead of classes, following the guidelines in GEMINI.md."
-    * "Generate comprehensive unit tests for the 'parseInput' function in 'src/parser/input.ts'. Ensure 
-      edge cases like empty strings and invalid characters are covered."
-
-* Bad \`prompt\` examples (cases attempting to pass file content directly to \`prompt\`):
-    * "Here is the file content: function processData(...) { ... }. Fix the bug."
-        * Reason: The Claude Code CLI will not recognize this string as file content; it will interpret
-          it as merely part of a long instruction. If file content needs to be read, you should specify
-          the file path in the prompt and let the Claude Code CLI read it itself.`,
-          },
-          timeout: {
-            type: Type.NUMBER,
-            description: `Optional timeout in milliseconds (default: ${ClaudeCodeTool.DEFAULT_TIMEOUT}).`,
-          },
-          continue: {
-            type: Type.BOOLEAN,
-            description: 'Optional: Whether to continue the previous session.',
-          },
-        },
-        required: ['prompt'],
-      },
-      false, // output is not markdown
-      true, // can update output (streaming)
-    );
-  }
-
-  /**
-   * Validates the parameters for the tool.
-   * @param params The parameters to validate.
-   * @returns A string containing the validation error, or null if validation succeeds.
-   */
-  validateToolParams(params: ClaudeCodeToolParams): string | null {
-    const errors = SchemaValidator.validate(this.schema.parameters, params);
-    if (errors) {
-      return errors;
-    }
-
-    if (!params.prompt || !params.prompt.trim()) {
-      return 'Prompt cannot be empty or just whitespace.';
-    }
-
-    if (params.timeout !== undefined) {
-      if (params.timeout <= 0) {
-        return 'Timeout must be a positive number.';
-      }
-      if (params.timeout > ClaudeCodeTool.MAX_TIMEOUT) {
-        return `Timeout cannot exceed ${ClaudeCodeTool.MAX_TIMEOUT / 1000 / 60} minutes (${ClaudeCodeTool.MAX_TIMEOUT}ms).`;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Gets a description of the tool's operation for logging.
-   * @param params The parameters for the tool.
-   * @returns A string describing the tool's operation.
-   */
-  getDescription(params: ClaudeCodeToolParams): string {
+  getDescription(): string {
     const promptPreview =
-      params.prompt.length > 200
-        ? `${params.prompt.substring(0, 200)}...`
-        : params.prompt;
+      this.params.prompt.length > 200
+        ? `${this.params.prompt.substring(0, 200)}...`
+        : this.params.prompt;
     return `Executing Claude Code with prompt: "${promptPreview}"`;
+  }
+
+  toolLocations(): ToolLocation[] {
+    return [];
+  }
+
+  shouldConfirmExecute(
+    _abortSignal: AbortSignal,
+  ): Promise<false | ToolCallConfirmationDetails> {
+    return Promise.resolve(false);
+  }
+
+  async execute(
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    // Execute Claude Code
+    const processResponse = await this.executeClaudeCode(
+      this.params,
+      signal,
+      updateOutput,
+    );
+
+    // Handle execution failure
+    if (!processResponse.success) {
+      const errorMessage = processResponse.error || 'Unknown error occurred';
+      return {
+        llmContent: `Error executing Claude Code: ${errorMessage}`,
+        returnDisplay: `❌ Claude Code execution failed: ${errorMessage}`,
+        error: {
+          message: errorMessage,
+          type: ToolErrorType.UNKNOWN,
+        },
+      };
+    }
+
+    // Parse the output
+    const parsedOutput = this.parseClaudeOutput(processResponse.output || '');
+
+    // Format the result
+    const metadata = {
+      executionTime: processResponse.executionTime,
+    };
+
+    const result = {
+      output: parsedOutput,
+      metadata,
+    };
+
+    // Create a user-friendly summary
+    let returnDisplay = '✅ Claude Code executed successfully\n\n';
+
+    // Use type guard to check if parsing failed
+    if (this.isRawOutput(parsedOutput)) {
+      // If parsing failed, show raw output
+      returnDisplay +=
+        '**Raw Output:**\n```\n' + parsedOutput.rawOutput + '\n```\n';
+    } else {
+      // If parsing succeeded, format the output nicely
+      returnDisplay +=
+        '**Result:**\n```json\n' +
+        JSON.stringify(parsedOutput, null, 2) +
+        '\n```\n';
+    }
+
+    returnDisplay += `\n**Execution Time:** ${processResponse.executionTime}ms`;
+
+    return {
+      summary: `Claude Code executed in ${processResponse.executionTime}ms`,
+      llmContent: JSON.stringify(result, null, 2),
+      returnDisplay,
+    };
   }
 
   /**
@@ -223,7 +210,7 @@ export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: false,
         // Use process groups on non-Windows for robust killing.
-        // Windows process termination is handled by `taskkill /t`.
+        // Windows termination is handled by `taskkill /t`.
         detached: !isWindows,
         env: {
           ...process.env,
@@ -339,89 +326,6 @@ export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
   }
 
   /**
-   * Executes the tool.
-   * @param params The parameters for the tool.
-   * @param signal An AbortSignal to cancel the process.
-   * @param updateOutput A callback to stream output updates.
-   * @returns A promise that resolves with the tool's result.
-   */
-  async execute(
-    params: ClaudeCodeToolParams,
-    signal: AbortSignal,
-    updateOutput?: (output: string) => void,
-  ): Promise<ToolResult> {
-    // Validate parameters
-    const validationError = this.validateToolParams(params);
-    if (validationError) {
-      return {
-        llmContent: `Error: Invalid parameters provided. Reason: ${validationError}`,
-        returnDisplay: `❌ ${validationError}`,
-        error: {
-          message: validationError,
-          type: ToolErrorType.INVALID_TOOL_PARAMS,
-        },
-      };
-    }
-
-    // Execute Claude Code
-    const processResponse = await this.executeClaudeCode(
-      params,
-      signal,
-      updateOutput,
-    );
-
-    // Handle execution failure
-    if (!processResponse.success) {
-      const errorMessage = processResponse.error || 'Unknown error occurred';
-      return {
-        llmContent: `Error executing Claude Code: ${errorMessage}`,
-        returnDisplay: `❌ Claude Code execution failed: ${errorMessage}`,
-        error: {
-          message: errorMessage,
-          type: ToolErrorType.UNKNOWN,
-        },
-      };
-    }
-
-    // Parse the output
-    const parsedOutput = this.parseClaudeOutput(processResponse.output || '');
-
-    // Format the result
-    const metadata = {
-      executionTime: processResponse.executionTime,
-    };
-
-    const result = {
-      output: parsedOutput,
-      metadata,
-    };
-
-    // Create a user-friendly summary
-    let returnDisplay = '✅ Claude Code executed successfully\n\n';
-
-    // Use type guard to check if parsing failed
-    if (this.isRawOutput(parsedOutput)) {
-      // If parsing failed, show raw output
-      returnDisplay +=
-        '**Raw Output:**\n```\n' + parsedOutput.rawOutput + '\n```\n';
-    } else {
-      // If parsing succeeded, format the output nicely
-      returnDisplay +=
-        '**Result:**\n```json\n' +
-        JSON.stringify(parsedOutput, null, 2) +
-        '\n```\n';
-    }
-
-    returnDisplay += `\n**Execution Time:** ${processResponse.executionTime}ms`;
-
-    return {
-      summary: `Claude Code executed in ${processResponse.executionTime}ms`,
-      llmContent: JSON.stringify(result, null, 2),
-      returnDisplay,
-    };
-  }
-
-  /**
    * Type guard to check if the output is a raw output.
    * @param output The parsed output to check.
    * @returns True if the output is a raw output, false otherwise.
@@ -430,5 +334,114 @@ export class ClaudeCodeTool extends BaseTool<ClaudeCodeToolParams, ToolResult> {
     output: ParsedClaudeOutput,
   ): output is ClaudeCodeRawOutput {
     return 'rawOutput' in output;
+  }
+}
+
+/**
+ * A tool for interacting with the Claude Code CLI.
+ */
+export class ClaudeCodeTool extends BaseDeclarativeTool< // Changed from BaseTool
+  ClaudeCodeToolParams,
+  ToolResult
+> {
+  static readonly Name: string = 'claude_code';
+  public static readonly DEFAULT_TIMEOUT = 1200000; // 20 minutes // Changed from private
+  public static readonly MAX_TIMEOUT = 6000000; // 60 minutes // Changed from private
+
+  constructor(private readonly config: Config) {
+    super(
+      ClaudeCodeTool.Name,
+      'ClaudeCode',
+      'Executes a prompt using the Claude Code CLI to perform complex code analysis, generation, and manipulation.',
+      Icon.Terminal,
+      {
+        type: Type.OBJECT,
+        properties: {
+          prompt: {
+            type: Type.STRING,
+            description: `About the prompt argument for the claude_code tool
+
+* Purpose: The prompt argument is a string that describes the specific task or instruction you want the
+  Claude Code CLI to execute. This is how you communicate the objective that the Claude Code CLI should
+  achieve, leveraging its internal tools (e.g., Bash, Read, Write, etc.).
+
+* Nature of Content:
+    * Instructions and Tasks: The prompt should contain concrete commands for the Claude Code CLI, such as
+      "Fix the bug in this file," "Refactor this module," or "Generate tests for this feature."
+    * Context Provision: If necessary, include additional context required for the task (e.g., "This code
+      is part of the authentication logic," "This function processes user input").
+    * File Path References: If you want operations to be performed on specific files or directories, refer
+      to their file paths within the 
+      prompt (e.g., "Optimize the calculateSum function in
+      src/utils/helper.ts").
+
+* Important Notes (to avoid misunderstanding):
+    * Not Direct File Content: You do not directly paste file content into the prompt argument. The
+      Claude Code CLI will, based on the instructions given in the prompt, read relevant files itself
+      using its Read tool or Bash tool (e.g., cat command) if necessary.
+    * Instruction for Claude Code CLI: It functions purely as an "instruction manual" for Claude Code
+      CLI, which is another AI agent.
+
+* Good 
+      prompt 
+      examples:
+    * "Fix the memory leak in 'src/data_processor.ts' related to the 'cache' object. Focus on lines
+      120-150."
+    * "Refactor the 'UserAuthService' class in 'packages/cli/src/services/auth.ts' to use functional
+      components instead of classes, following the guidelines in GEMINI.md."
+    * "Generate comprehensive unit tests for the 'parseInput' function in 'src/parser/input.ts'. Ensure
+      edge cases like empty strings and invalid characters are covered."
+
+* Bad 
+      prompt 
+      examples (cases attempting to pass file content directly to 
+      prompt):
+    * "Here is the file content: function processData(...) { ... }. Fix the bug."
+        * Reason: The Claude Code CLI will not recognize this string as file content; it will interpret
+          it as merely part of a long instruction. If file content needs to be read, you should specify
+          the file path in the prompt and let the Claude Code CLI read it itself.`,
+          },
+          timeout: {
+            type: Type.NUMBER,
+            description: `Optional timeout in milliseconds (default: ${ClaudeCodeTool.DEFAULT_TIMEOUT}).`,
+          },
+          continue: {
+            type: Type.BOOLEAN,
+            description: 'Optional: Whether to continue the previous session.',
+          },
+        },
+        required: ['prompt'],
+      },
+      false, // output is not markdown
+      true, // can update output (streaming)
+    );
+  }
+
+  protected validateToolParams(params: ClaudeCodeToolParams): string | null {
+    const errors = SchemaValidator.validate(this.schema.parameters, params);
+    if (errors) {
+      return errors;
+    }
+
+    if (!params.prompt || !params.prompt.trim()) {
+      return 'Prompt cannot be empty or just whitespace.';
+    }
+
+    if (params.timeout !== undefined) {
+      if (params.timeout <= 0) {
+        return 'Timeout must be a positive number.';
+      }
+      if (params.timeout > ClaudeCodeTool.MAX_TIMEOUT) {
+        return `Timeout cannot exceed ${ClaudeCodeTool.MAX_TIMEOUT / 1000 / 60} minutes (${ClaudeCodeTool.MAX_TIMEOUT}ms).`;
+      }
+    }
+
+    return null;
+  }
+
+  protected createInvocation(
+    params: ClaudeCodeToolParams,
+  ): ToolInvocation<ClaudeCodeToolParams, ToolResult> {
+    return new ClaudeCodeToolInvocation(params, this.config);
   }
 }


### PR DESCRIPTION
Refactored ClaudeCodeTool to align with the new declarative tool pattern.
- Changed base class from BaseTool to BaseDeclarativeTool.
- Introduced ClaudeCodeToolInvocation to encapsulate execution logic.
- Moved relevant methods (executeClaudeCode, killProcess, parseClaudeOutput, isRawOutput) to ClaudeCodeToolInvocation.
- Updated shouldConfirmExecute signature and made DEFAULT_TIMEOUT/MAX_TIMEOUT public for accessibility.