### PR TITLE
feat(tools): add Forbidden icon for deprecated EditTool

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -523,20 +523,8 @@ export class EditTool
     super(
       EditTool.Name,
       'Edit',
-      `[DEPRECATED] This tool is deprecated in favor of using claude_code for more flexible and powerful code generation and modification. Replaces text within a file. By default, replaces a single occurrence, but can replace multiple occurrences when 
-expected_replacements
- is specified. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${ReadFileTool.Name} tool to examine the file's current content before attempting a text replacement.
-
-      The user has the ability to modify the \`new_string\` content. If modified, this will be stated in the response.
-
-Expectation for required parameters:
-1. \`file_path\` MUST be an absolute path; otherwise an error will be thrown.
-2. \`old_string\` MUST be the exact literal text to replace (including all whitespace, indentation, newlines, and surrounding code etc.).
-3. \`new_string\` MUST be the exact literal text to replace \`old_string\` with (also including all whitespace, indentation, newlines, and surrounding code etc.). Ensure the resulting code is correct and idiomatic.
-4. NEVER escape \`old_string\` or \`new_string\`, that would break the exact literal text requirement.
-**Important:** If ANY of the above are not satisfied, the tool will fail. CRITICAL for \`old_string\`: Must uniquely identify the single instance to change. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string matches multiple locations, or does not match exactly, the tool will fail.
-**Multiple replacements:** Set \`expected_replacements\` to the number of occurrences you want to replace. The tool will replace ALL occurrences that match \`old_string\` exactly. Ensure the number of replacements matches your expectation.`,
-      Icon.Pencil,
+      `[DEPRECATED] DO NOT USE. This tool is unreliable and will be removed. Use the 'claude_code' tool for all file modifications. This tool is for legacy reference only and its use is strictly forbidden.`,
+      Icon.Forbidden,
       {
         properties: {
           file_path: {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -573,6 +573,7 @@ export enum ToolConfirmationOutcome {
 export enum Icon {
   FileSearch = 'fileSearch',
   Folder = 'folder',
+  Forbidden = 'forbidden',
   Globe = 'globe',
   Hammer = 'hammer',
   LightBulb = 'lightBulb',


### PR DESCRIPTION
The `EditTool` (replace) is deprecated, but its UI representation (a pencil icon and a descriptive 'how-to' message) was misleading and could encourage its use.

This commit addresses this by:
1.  Adding a new `Forbidden` icon to the `Icon` enum.
2.  Updating the tool's description to be an unambiguous warning.
3.  Applying the new `Forbidden` icon to the tool.

This makes the tool's deprecated status clear and prevents accidental use, improving developer experience and system robustness.
