### PR TITLE
feat: Migrate tool icon to kind enum

### DIFF
--- a/packages/cli/src/acp/acp.ts
+++ b/packages/cli/src/acp/acp.ts
@@ -6,7 +6,7 @@
 
 /* ACP defines a schema for a simple (experimental) JSON-RPC protocol that allows GUI applications to interact with agents. */
 
-import { Icon } from '@google/gemini-cli-core';
+import { Kind } from '@google/gemini-cli-core';
 import { WritableStream, ReadableStream } from 'node:stream/web';
 
 export class ClientConnection implements Client {
@@ -352,7 +352,7 @@ export interface StreamAssistantMessageChunkParams {
 export interface RequestToolCallConfirmationParams {
   confirmation: ToolCallConfirmation;
   content?: ToolCallContent | null;
-  icon: Icon;
+  kind: Kind;
   label: string;
   locations?: ToolCallLocation[];
 }
@@ -364,7 +364,7 @@ export interface ToolCallLocation {
 
 export interface PushToolCallParams {
   content?: ToolCallContent | null;
-  icon: Icon;
+  kind: Kind;
   label: string;
   locations?: ToolCallLocation[];
 }

--- a/packages/cli/src/acp/acpPeer.ts
+++ b/packages/cli/src/acp/acpPeer.ts
@@ -257,7 +257,7 @@ class GeminiAgent implements Agent {
 
         const result = await this.client.requestToolCallConfirmation({
           label: invocation.getDescription(),
-          icon: tool.icon,
+          kind: tool.kind,
           content,
           confirmation: toAcpToolCallConfirmation(confirmationDetails),
           locations: invocation.toolLocations(),
@@ -287,7 +287,7 @@ class GeminiAgent implements Agent {
         toolCallId = result.id;
       } else {
         const result = await this.client.pushToolCall({
-          icon: tool.icon,
+          kind: tool.kind,
           label: invocation.getDescription(),
           locations: invocation.toolLocations(),
         });
@@ -532,7 +532,7 @@ class GeminiAgent implements Agent {
     try {
       const invocation = readManyFilesTool.build(toolArgs);
       const toolCall = await this.client.pushToolCall({
-        icon: readManyFilesTool.icon,
+        kind: readManyFilesTool.kind,
         label: invocation.getDescription(),
       });
       toolCallId = toolCall.id;

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -19,7 +19,7 @@ import {
   ToolConfirmationPayload,
   ToolResult,
   Config,
-  Icon,
+  Kind,
   ApprovalMode,
 } from '../index.js';
 import { Part, PartListUnion } from '@google/genai';
@@ -389,7 +389,7 @@ describe('CoreToolScheduler edit cancellation', () => {
           'mockEditTool',
           'mockEditTool',
           'A mock edit tool',
-          Icon.Pencil,
+          Kind.Edit,
           {},
         );
       }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -255,6 +255,7 @@ export class Turn {
                   : 'Agreement requested',
               },
             };
+            continue;
           } else {
             yield { type: GeminiEventType.Content, value: text };
           }

--- a/packages/core/src/test-utils/tools.ts
+++ b/packages/core/src/test-utils/tools.ts
@@ -7,7 +7,7 @@
 import { vi } from 'vitest';
 import {
   BaseTool,
-  Icon,
+  Kind,
   ToolCallConfirmationDetails,
   ToolResult,
 } from '../tools/tools.js';
@@ -29,7 +29,7 @@ export class MockTool extends BaseTool<{ [key: string]: unknown }, ToolResult> {
       properties: { param: { type: Type.STRING } },
     },
   ) {
-    super(name, displayName ?? name, description, Icon.Hammer, params);
+    super(name, displayName ?? name, description, Kind.Edit, params);
   }
 
   async execute(

--- a/packages/core/src/tools/claudeCodeTool.ts
+++ b/packages/core/src/tools/claudeCodeTool.ts
@@ -10,7 +10,7 @@ import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
 import {
   BaseDeclarativeTool,
-  Icon,
+  Kind,
   ToolResult,
   ToolInvocation,
   ToolLocation,
@@ -353,7 +353,7 @@ export class ClaudeCodeTool extends BaseDeclarativeTool< // Changed from BaseToo
       ClaudeCodeTool.Name,
       'ClaudeCode',
       'Executes a prompt using the Claude Code CLI to perform complex code analysis, generation, and manipulation.',
-      Icon.Terminal,
+      Kind.Execute,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/comfyEditorTool.ts
+++ b/packages/core/src/tools/comfyEditorTool.ts
@@ -9,7 +9,7 @@ import { executeWorkflowUpdates } from './comfy-editor/tool.js';
 import { ToolErrorType } from './tool-error.js';
 import {
   BaseDeclarativeTool, // Changed from BaseTool
-  Icon,
+  Kind,
   ToolResult,
   ToolInvocation, // Added
   ToolLocation, // Added
@@ -92,7 +92,7 @@ export class ComfyEditorTool extends BaseDeclarativeTool<
       'ComfyEditor',
       // TODO(b/12345): Clarify that 'nodeTitle' refers to the user-set 'title' property in the JSON, which may not exist by default. The tool should be improved to fall back to other identifiers like node ID or properties['Node name for S&R'].
       'Programmatically edits a ComfyUI workflow JSON file by applying a series of updates.',
-      Icon.Pencil,
+      Kind.Edit,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -10,7 +10,7 @@ import * as Diff from 'diff';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
-  Icon,
+  Kind,
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
   ToolEditConfirmationDetails,
@@ -524,7 +524,7 @@ export class EditTool
       EditTool.Name,
       'Edit',
       `[DEPRECATED] DO NOT USE. This tool is unreliable and will be removed. Use the 'claude_code' tool for all file modifications. This tool is for legacy reference only and its use is strictly forbidden.`,
-      Icon.Forbidden,
+      Kind.Other,
       {
         properties: {
           file_path: {

--- a/packages/core/src/tools/gitTool.ts
+++ b/packages/core/src/tools/gitTool.ts
@@ -12,7 +12,7 @@ import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
 import {
   BaseDeclarativeTool, // Changed from BaseTool
-  Icon,
+  Kind,
   ToolResult,
   ToolInvocation, // Added
   ToolLocation, // Added
@@ -291,7 +291,7 @@ export class GitTool extends BaseDeclarativeTool<GitToolParams, ToolResult> {
       GitTool.Name,
       'Git',
       'Executes Git commands robustly and securely.',
-      Icon.Terminal, // Or a more specific Git icon if available
+      Kind.Execute, // Or a more specific Git icon if available
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/githubTool.ts
+++ b/packages/core/src/tools/githubTool.ts
@@ -12,7 +12,7 @@ import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
 import {
   BaseDeclarativeTool, // Changed from BaseTool
-  Icon,
+  Kind,
   ToolResult,
   ToolInvocation, // Added
   ToolLocation, // Added
@@ -304,7 +304,7 @@ export class GitHubTool extends BaseDeclarativeTool<GitHubToolParams, ToolResult
       GitHubTool.Name,
       'GitHub CLI',
       'Executes GitHub CLI (gh) commands for repository management, pull requests, issues, and more.',
-      Icon.Terminal,
+      Kind.Execute,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -11,7 +11,7 @@ import { SchemaValidator } from '../utils/schemaValidator.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
-  Icon,
+  Kind,
   ToolInvocation,
   ToolResult,
 } from './tools.js';
@@ -249,7 +249,7 @@ export class GlobTool extends BaseDeclarativeTool<GlobToolParams, ToolResult> {
       GlobTool.Name,
       'FindFiles',
       'Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning absolute paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.',
-      Icon.FileSearch,
+      Kind.Search,
       {
         properties: {
           pattern: {

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -13,7 +13,7 @@ import { globStream } from 'glob';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
-  Icon,
+  Kind,
   ToolInvocation,
   ToolResult,
 } from './tools.js';
@@ -544,7 +544,7 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
       GrepTool.Name,
       'SearchText',
       'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers.',
-      Icon.Regex,
+      Kind.Search,
       {
         properties: {
           pattern: {

--- a/packages/core/src/tools/intelligent-read-file-v2.ts
+++ b/packages/core/src/tools/intelligent-read-file-v2.ts
@@ -7,7 +7,7 @@
 import path from 'path';
 import { glob } from 'glob';
 import { SchemaValidator } from '../utils/schemaValidator.js';
-import { BaseTool, Icon, ToolLocation, ToolResult } from './tools.js';
+import { BaseTool, Kind, ToolLocation, ToolResult } from './tools.js';
 import { Type } from '@google/genai';
 import {
   processSingleFileContent,
@@ -43,7 +43,7 @@ export class IntelligentReadTool extends BaseTool<
       IntelligentReadTool.Name,
       'IntelligentRead',
       'Reads file content by intelligently resolving partial paths or file names. Can find files using absolute paths, relative paths, or just file names.',
-      Icon.FileSearch,
+      Kind.Search,
       {
         properties: {
           pathHint: {

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -6,7 +6,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { BaseTool, Icon, ToolResult, ToolLocation } from './tools.js';
+import { BaseTool, Kind, ToolResult, ToolLocation } from './tools.js';
 import { Type } from '@google/genai';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import { Config, DEFAULT_FILE_FILTERING_OPTIONS } from '../config/config.js';
@@ -75,7 +75,7 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
       LSTool.Name,
       'ReadFolder',
       'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
-      Icon.Folder,
+      Kind.Read,
       {
         properties: {
           path: {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -10,7 +10,7 @@ import {
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
   ToolMcpConfirmationDetails,
-  Icon,
+  Kind,
 } from './tools.js';
 import {
   CallableTool,
@@ -73,7 +73,7 @@ export class DiscoveredMCPTool extends BaseTool<ToolParams, ToolResult> {
       nameOverride ?? generateValidName(serverToolName),
       `${serverToolName} (${serverName} MCP Server)`,
       description,
-      Icon.Hammer,
+      Kind.Edit,
       { type: Type.OBJECT }, // this is a dummy Schema for MCP, will be not be used to construct the FunctionDeclaration
       true, // isOutputMarkdown
       false, // canUpdateOutput

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -9,7 +9,7 @@ import {
   ToolResult,
   ToolEditConfirmationDetails,
   ToolConfirmationOutcome,
-  Icon,
+  Kind,
 } from './tools.js';
 import { FunctionDeclaration, Type } from '@google/genai';
 import * as fs from 'fs/promises';
@@ -122,7 +122,7 @@ export class MemoryTool
       MemoryTool.Name,
       'Save Memory',
       memoryToolDescription,
-      Icon.LightBulb,
+      Kind.Think,
       memoryToolSchemaData.parameters as Record<string, unknown>,
     );
   }

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -11,7 +11,7 @@ import { makeRelative, shortenPath } from '../utils/paths.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
-  Icon,
+  Kind,
   ToolInvocation,
   ToolLocation,
   ToolResult,
@@ -174,7 +174,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
       ReadFileTool.Name,
       'ReadFile',
       `Reads and returns the content of a specified file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.`,
-      Icon.FileSearch,
+      Kind.Search,
       {
         properties: {
           pathHint: {

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BaseTool, Icon, ToolResult } from './tools.js';
+import { BaseTool, Kind, ToolResult } from './tools.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 import { getErrorMessage } from '../utils/errors.js';
 import * as path from 'path';
@@ -230,7 +230,7 @@ This tool is useful when you need to understand or analyze a collection of files
 - When the user asks to "read all files in X directory" or "show me the content of all Y files".
 
 Use this tool when the user's query implies needing the content of several files simultaneously for context, analysis, or summarization. For text files, it uses default UTF-8 encoding and a '--- {filePath} ---' separator between file contents. Ensure paths are relative to the target directory. Glob patterns like 'src/**/*.js' are supported. Avoid using for single files if a more specific single-file reading tool is available, unless the user specifically requests to process a list containing just one file via this tool. Other binary files (not explicitly requested as image/PDF) are generally skipped. Default excludes apply to common non-text files (except for explicitly requested images/PDFs) and large dependency directories unless 'useDefaultExcludes' is false.`,
-      Icon.FileSearch,
+      Kind.Search,
       parameterSchema,
     );
   }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -15,7 +15,7 @@ import {
   ToolCallConfirmationDetails,
   ToolExecuteConfirmationDetails,
   ToolConfirmationOutcome,
-  Icon,
+  Kind,
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
@@ -62,7 +62,7 @@ export class ShellTool extends BaseTool<ShellToolParams, ToolResult> {
       Signal: Signal number or \`(none)\` if no signal was received.
       Background PIDs: List of background processes started or \`(none)\`.
       Process Group PGID: Process group started or \`(none)\``,
-      Icon.Terminal,
+      Kind.Execute,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/shikiTool.ts
+++ b/packages/core/src/tools/shikiTool.ts
@@ -8,7 +8,7 @@ import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
 import { 
   BaseDeclarativeTool, // Changed from BaseTool
-  Icon,
+  Kind,
   ToolResult,
   ToolInvocation, // Added
   ToolLocation, // Added
@@ -437,7 +437,7 @@ export class ShikiTool extends BaseDeclarativeTool<ShikiToolParams, ToolResult> 
       ShikiTool.Name,
       'Shiki',
       'A tool to create and manage tasks in the Shiki system.',
-      Icon.Hammer,
+      Kind.Edit,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -5,7 +5,7 @@
  */
 
 import { FunctionDeclaration, Schema, Type } from '@google/genai';
-import { AnyDeclarativeTool, Icon, ToolResult, BaseTool } from './tools.js';
+import { AnyDeclarativeTool, Kind, ToolResult, BaseTool } from './tools.js';
 import { Config } from '../config/config.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
@@ -44,7 +44,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
       name,
       name,
       description,
-      Icon.Hammer,
+      Kind.Edit,
       parameterSchema,
       false, // isOutputMarkdown
       false, // canUpdateOutput

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -147,7 +147,7 @@ export interface ToolBuilder<
   /**
    * The icon to display when interacting via ACP.
    */
-  icon: Icon;
+  kind: Kind;
 
   /**
    * Function declaration schema from @google/genai.
@@ -185,7 +185,7 @@ export abstract class DeclarativeTool<
     readonly name: string,
     readonly displayName: string,
     readonly description: string,
-    readonly icon: Icon,
+    readonly kind: Kind,
     readonly parameterSchema: Schema,
     readonly isOutputMarkdown: boolean = true,
     readonly canUpdateOutput: boolean = false,
@@ -287,7 +287,7 @@ export abstract class BaseTool<
     readonly name: string,
     readonly displayName: string,
     readonly description: string,
-    readonly icon: Icon,
+    readonly kind: Kind,
     readonly parameterSchema: Schema,
     readonly isOutputMarkdown: boolean = true,
     readonly canUpdateOutput: boolean = false,
@@ -296,7 +296,7 @@ export abstract class BaseTool<
       name,
       displayName,
       description,
-      icon,
+      kind,
       parameterSchema,
       isOutputMarkdown,
       canUpdateOutput,
@@ -570,16 +570,16 @@ export enum ToolConfirmationOutcome {
   Cancel = 'cancel',
 }
 
-export enum Icon {
-  FileSearch = 'fileSearch',
-  Folder = 'folder',
-  Forbidden = 'forbidden',
-  Globe = 'globe',
-  Hammer = 'hammer',
-  LightBulb = 'lightBulb',
-  Pencil = 'pencil',
-  Regex = 'regex',
-  Terminal = 'terminal',
+export enum Kind {
+  Read = 'read',
+  Edit = 'edit',
+  Delete = 'delete',
+  Move = 'move',
+  Search = 'search',
+  Execute = 'execute',
+  Think = 'think',
+  Fetch = 'fetch',
+  Other = 'other',
 }
 
 export interface ToolLocation {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -10,7 +10,7 @@ import {
   ToolResult,
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
-  Icon,
+  Kind,
 } from './tools.js';
 import { Type } from '@google/genai';
 import { getErrorMessage } from '../utils/errors.js';
@@ -71,7 +71,7 @@ export class WebFetchTool extends BaseTool<WebFetchToolParams, ToolResult> {
       WebFetchTool.Name,
       'WebFetch',
       "Processes content from URL(s), including local and private network addresses (e.g., localhost), embedded in a prompt. Include up to 20 URLs and instructions (e.g., summarize, extract specific data) directly in the 'prompt' parameter.",
-      Icon.Globe,
+      Kind.Fetch,
       {
         properties: {
           prompt: {

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -5,7 +5,7 @@
  */
 
 import { GroundingMetadata } from '@google/genai';
-import { BaseTool, Icon, ToolResult } from './tools.js';
+import { BaseTool, Kind, ToolResult } from './tools.js';
 import { Type } from '@google/genai';
 import { SchemaValidator } from '../utils/schemaValidator.js';
 
@@ -69,7 +69,7 @@ export class WebSearchTool extends BaseTool<
       WebSearchTool.Name,
       'GoogleSearch',
       'Performs a web search using Google Search (via the Gemini API) and returns the results. This tool is useful for finding information on the internet based on a query.',
-      Icon.Globe,
+      Kind.Fetch,
       {
         type: Type.OBJECT,
         properties: {

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -15,7 +15,7 @@ import {
   ToolEditConfirmationDetails,
   ToolConfirmationOutcome,
   ToolCallConfirmationDetails,
-  Icon,
+  Kind,
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { Type } from '@google/genai';
@@ -83,7 +83,7 @@ export class WriteFileTool
       `Writes content to a specified file in the local filesystem.
 
       The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
-      Icon.Pencil,
+      Kind.Edit,
       {
         properties: {
           file_path: {


### PR DESCRIPTION
Renames the `Icon` enum to `Kind` and updates all references across the codebase.
This aligns the tool categorization with the new architecture, where `kind` represents
the type of operation rather than a visual icon.

- Renamed `Icon` enum to `Kind` in `packages/core/src/tools/tools.ts`.
- Updated `Kind` enum members to reflect operational types (Read, Edit, Search, etc.).
- Replaced `icon: Icon` with `kind: Kind` in `ToolBuilder` and `DeclarativeTool` interfaces/classes.
- Updated all tool implementations to use `Kind` enum values based on their operational type.
- Fixed import and property access errors related to the `Icon` to `Kind` migration.