### PR TITLE
feat(cli): add --auth-method command-line flag

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -28,6 +28,7 @@ import {
   WriteFileTool,
   MCPServerConfig,
   getCoreSystemPrompt,
+  AuthType,
 } from '@google/gemini-cli-core';
 import { Settings } from './settings.js';
 
@@ -80,6 +81,7 @@ export interface CliArgs {
   systemPrompt?: string;
   systemPromptFile?: string;
   skipMemory?: boolean;
+  authMethod?: string;
 }
 
 export async function parseArguments(): Promise<CliArgs> {
@@ -263,6 +265,11 @@ export async function parseArguments(): Promise<CliArgs> {
           type: 'boolean',
           description: 'Do not load any memory from GEMINI.md files.',
           default: false,
+        })
+        .option('auth-method', {
+          type: 'string',
+          description: 'Specify the authentication method.',
+          choices: ['login-with-google', 'cloud-shell', 'use-gemini', 'use-vertex-ai'],
         })
         .check((argv) => {
           if (argv.prompt && argv.promptInteractive) {
@@ -731,6 +738,7 @@ export async function loadCliConfig(
     folderTrustFeature,
     folderTrust,
     interactive,
+    authMethod: argv.authMethod as AuthType,
   });
 }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -206,6 +206,7 @@ export interface ConfigParameters {
   chatCompression?: ChatCompressionSettings;
   interactive?: boolean;
   shikiManagerApiUrl?: string;
+  authMethod?: AuthType;
 }
 
 export class Config {
@@ -273,6 +274,7 @@ export class Config {
   private readonly interactive: boolean;
   private initialized: boolean = false;
   private readonly shikiManagerApiUrl: string;
+  private readonly authMethod: AuthType | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId;
@@ -343,6 +345,7 @@ export class Config {
     this.interactive = params.interactive ?? false;
     this.shikiManagerApiUrl =
       params.shikiManagerApiUrl ?? 'http://localhost:8080';
+    this.authMethod = params.authMethod;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -723,6 +726,10 @@ export class Config {
 
   getShikiManagerApiUrl(): string {
     return this.shikiManagerApiUrl;
+  }
+
+  getAuthMethod(): AuthType | undefined {
+    return this.authMethod;
   }
 
   async getGitService(): Promise<GitService> {


### PR DESCRIPTION
Introduces a new `--auth-method` flag to allow users to specify the authentication method directly upon startup.

This provides a non-interactive way to select the auth provider (`login-with-google`, `cloud-shell`, `use-gemini`, `use-vertex-ai`), overriding any previously saved settings in `settings.json`.

The implementation involves:
- Adding the `--auth-method` option in `packages/cli/src/config/config.ts`.
- Passing the selected method through the `Config` object in `packages/core/src/config/config.ts`.
- Adding a `useEffect` hook in `packages/cli/src/ui/App.tsx` to handle the initial authentication based on the provided flag.
