### PR TITLE
feat(core): Handle duplicate subcommands in git_tool

### DIFF
--- a/packages/core/src/tools/gitTool.ts
+++ b/packages/core/src/tools/gitTool.ts
@@ -95,6 +95,11 @@ class GitToolInvocation implements ToolInvocation<GitToolParams, ToolResult> {
     signal: AbortSignal,
     updateOutput?: (output: string) => void,
   ): Promise<GitProcessResponse> {
+    // De-duplicate command and args. e.g., `git status status` -> `git status`
+    if (params.args && params.args.length > 0 && params.command === params.args[0]) {
+      params.args.shift(); // Remove the duplicate from the start of args
+    }
+
     const startTime = Date.now();
     console.log(
       `[GitTool] executeGitCommand started for command: ${params.command}`,


### PR DESCRIPTION
LLMs may occasionally repeat subcommands, leading to calls like `git status status`. This change makes the `git_tool` more robust by deduplicating the `command` and the first `arg` if they are identical.

- Adds logic to `gitTool.ts` to remove the redundant subcommand from the arguments.
- Adds a corresponding unit test in `gitTool.test.ts` to verify this behavior.

