### PR TITLE
fix(ui): Prevent duplicate submissions in useMessageQueue

### DIFF
--- a/packages/cli/src/ui/hooks/useMessageQueue.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.ts
@@ -58,7 +58,10 @@ export function useMessageQueue({
       setMessageQueue([]);
       submitQuery(combinedMessage);
     }
-  }, [streamingState, messageQueue, submitQuery]);
+    // Only re-run when streamingState changes, not when messageQueue changes
+    // This prevents duplicate submissions when messages are queued
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streamingState]);
 
   return {
     messageQueue,


### PR DESCRIPTION
The useEffect in useMessageQueue had a dependency on `messageQueue` and `submitQuery`. This could cause a race condition where the effect would re-trigger itself when multiple messages were queued rapidly, leading to duplicate query submissions.

This change modifies the dependency array to only include `streamingState`, ensuring the submission logic only runs once when the streaming state becomes idle. An `eslint-disable-next-line` is added to account for the intentionally omitted dependencies.

