### PR TITLE
feat(core): provide detailed empty stream errors

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -581,10 +581,14 @@ export class GeminiChat {
     }
 
     // Now that the stream is finished, make a decision.
-    // Throw an error if the stream was invalid OR if it was completely empty.
-    if (isStreamInvalid || !hasReceivedAnyChunk) {
+    if (!hasReceivedAnyChunk) {
       throw new EmptyStreamError(
-        'Model stream was invalid or completed without valid content.',
+        'Model stream completed without yielding any chunks. This may be due to a content filter or a server-side issue.',
+      );
+    }
+    if (isStreamInvalid) {
+      throw new EmptyStreamError(
+        'Model stream included an invalid chunk and was terminated.',
       );
     }
 


### PR DESCRIPTION
Investigate intermittent "Model stream was invalid" errors.

This change differentiates between two potential causes for the `EmptyStreamError`:
1.  The stream completes with no chunks, possibly due to content filters or server-side issues.
2.  The stream includes an invalid chunk during transmission.

By providing more specific error messages for each case, we can better diagnose the root cause of the failure upon its next occurrence.
