### PR TITLE
feat(ui): Run StrictMode only in debug mode

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -352,19 +352,25 @@ export async function main() {
     // Detect and enable Kitty keyboard protocol once at startup
     await detectAndEnableKittyProtocol();
     setWindowTitle(basename(workspaceRoot), settings);
+    const appContent = (
+      <SettingsContext.Provider value={settings}>
+        <AppWrapper
+          config={config}
+          settings={settings}
+          startupWarnings={startupWarnings}
+          version={version}
+          noSelfIntroduce={argv.noSelfIntroduce}
+          workspaceRoot={workspaceRoot}
+        />
+      </SettingsContext.Provider>
+    );
+
     const instance = render(
-      <React.StrictMode>
-        <SettingsContext.Provider value={settings}>
-          <AppWrapper
-            config={config}
-            settings={settings}
-            startupWarnings={startupWarnings}
-            version={version}
-            noSelfIntroduce={argv.noSelfIntroduce}
-            workspaceRoot={workspaceRoot}
-          />
-        </SettingsContext.Provider>
-      </React.StrictMode>,
+      config.getDebugMode() ? (
+        <React.StrictMode>{appContent}</React.StrictMode>
+      ) : (
+        appContent
+      ),
       { exitOnCtrlC: false },
     );
 


### PR DESCRIPTION
React.StrictMode is a valuable tool for identifying potential problems and side effects during development by intentionally double-rendering components.

However, in the context of this sequential CLI application, this behavior was causing unintended side effects, such as duplicate submissions, which required workarounds (e.g., `useRef` guards).

This change makes `StrictMode` only apply when `config.getDebugMode()` is true. This resolves the root cause of the duplicate submission issues in normal execution, improving stability and performance, while retaining its benefits for dedicated debugging sessions.

